### PR TITLE
Fix duplicate workflow runs in lint-frontend workflow

### DIFF
--- a/.github/workflows/lint-frontend.yaml
+++ b/.github/workflows/lint-frontend.yaml
@@ -3,7 +3,7 @@ name: Lint (frontend)
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes duplicate workflow runs by restricting push triggers to main branch only, preventing the workflow from running twice (once on push, once on PR) for feature branches.

# Problem

The  workflow was configured to trigger on pushes to all branches (), which caused duplicate workflow runs when a branch was part of a pull request. The workflow would run once on the push event and again on the pull_request event, wasting CI resources and creating confusion.

# Solution

Changed the push trigger to only target the  branch instead of all branches. This ensures:
- The workflow runs on pushes to  (as intended)
- The workflow runs on PRs targeting  (via pull_request event)
- The workflow does NOT run on pushes to feature branches (unless they're part of a PR, in which case the pull_request event handles it)
- Eliminates duplicate runs for PR branches

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)