### PR TITLE
Fix CI workflow inconsistency with branch protection rules

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -4,29 +4,36 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-    paths:
-      - 'bookcard/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/ci-backend.yaml'
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'bookcard/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/ci-backend.yaml'
 
 concurrency:
   group: ci-backend-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'bookcard/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci-backend.yaml'
+
   lint:
     name: Lint & Typecheck
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +67,8 @@ jobs:
 
   test-and-build:
     name: Test & Build (Python ${{ matrix.python-version }} on ${{ matrix.os }})
-    needs: lint
+    needs: [changes, lint]
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -4,23 +4,33 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-    paths:
-      - 'web/**'
-      - '.github/workflows/ci-frontend.yaml'
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'web/**'
-      - '.github/workflows/ci-frontend.yaml'
 
 concurrency:
   group: ci-frontend-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'web/**'
+              - '.github/workflows/ci-frontend.yaml'
+
   lint:
     name: Lint & Typecheck
+    needs: changes
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -46,7 +56,8 @@ jobs:
 
   test-and-build:
     name: Test & Build (Node ${{ matrix.node-version }})
-    needs: lint
+    needs: [changes, lint]
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixed CI workflows to ensure status checks are always reported to GitHub, even when no relevant files are changed, preventing PRs from being stuck in "Expected" state and requiring bypasses to merge.

# Problem

The CI workflows ( and ) used  filters in the  trigger to conditionally run workflows based on file changes. While this correctly prevents unnecessary CI runs, it creates an inconsistency with GitHub's branch protection rules:

- When a PR doesn't touch backend/frontend files, the workflows don't trigger at all
- GitHub's "Required Status Checks" expect these checks to exist and report a status (Success, Failure, or Skipped)
- Since the workflows never run, no status is posted, leaving checks in an "Expected" state
- This blocks PRs from merging and requires manual bypasses of branch protection rules

# Solution

Replaced static  filters in workflow triggers with dynamic path detection using the  action:

1. **Removed  filters** from  and  triggers - workflows now always trigger
2. **Added a lightweight  job** that uses  to detect if relevant files were modified
3. **Added conditional execution** to  and  jobs using 

This ensures:
- Workflows always run and post status checks to GitHub
- When no relevant files are changed, jobs are marked as "Skipped" (which satisfies branch protection requirements)
- When relevant files are changed, jobs run normally
- PRs can merge without bypassing branch protection rules

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)