### PR TITLE
Fix SQLAlchemy warnings in tests and queries

### DIFF
--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -495,7 +495,10 @@ def mock_engine() -> MagicMock:
     MagicMock
         A mock database engine.
     """
-    return MagicMock(spec=Engine)
+    engine = MagicMock(spec=Engine)
+    # Configure connect().in_transaction() to return False to avoid SAWarning
+    engine.connect.return_value.in_transaction.return_value = False
+    return engine
 
 
 @pytest.fixture

--- a/tests/services/ingest/test_ingest_watcher_service.py
+++ b/tests/services/ingest/test_ingest_watcher_service.py
@@ -36,7 +36,10 @@ from bookcard.services.ingest.ingest_watcher_service import IngestWatcherService
 @pytest.fixture
 def mock_engine() -> MagicMock:
     """Create a mock database engine."""
-    return MagicMock()
+    engine = MagicMock()
+    # Configure connect().in_transaction() to return False to avoid SAWarning
+    engine.connect.return_value.in_transaction.return_value = False
+    return engine
 
 
 @pytest.fixture

--- a/tests/services/scheduler/test_task_scheduler.py
+++ b/tests/services/scheduler/test_task_scheduler.py
@@ -30,7 +30,10 @@ from tests.conftest import DummySession
 @pytest.fixture
 def mock_engine() -> MagicMock:
     """Create a mock database engine."""
-    return MagicMock()
+    engine = MagicMock()
+    # Configure connect().in_transaction() to return False to avoid SAWarning
+    engine.connect.return_value.in_transaction.return_value = False
+    return engine
 
 
 @pytest.fixture


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes SQLAlchemy warnings about coercing Subquery objects in IN() clauses and connection transaction state warnings in test fixtures.

# Problem

The test suite was producing SQLAlchemy warnings:
1. **Subquery coercion warning**:  was returning a compiled  object, but SQLAlchemy's  operator prefers a  construct. This caused warnings: "Coercing Subquery object into a select() for use in IN(); please pass a select() construct explicitly"
2. **Transaction state warning**: Mock database engines in test fixtures were not properly configured, causing SQLAlchemy to think connections were already in transactions, leading to warnings: "The engine provided as bind produced a connection that is already in a transaction"

# Solution

1. **Query builder fix**: Modified  to return a  object instead of a compiled . The subquery is still created for the count operation, but the method now returns the original  statement which can be properly used with .
2. **Test fixture fixes**: Updated  fixtures in , , and  to explicitly configure  to return , preventing false transaction state detection.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)