### PR TITLE
Fix CI workflow status checks for branch protection rules

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Check for backend changes
         id: check_changes
+        shell: bash
         run: |
           if [ "${{ needs.changes.outputs.backend }}" != "true" ]; then
             echo "No backend changes detected, skipping lint and typecheck"
@@ -95,6 +96,7 @@ jobs:
     steps:
       - name: Check for backend changes
         id: check_changes
+        shell: bash
         run: |
           if [ "${{ needs.changes.outputs.backend }}" != "true" ]; then
             echo "No backend changes detected, skipping test and build"

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -33,12 +33,10 @@ jobs:
     name: Lint & Typecheck
     needs: changes
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./web
     steps:
       - name: Check for frontend changes
         id: check_changes
+        shell: bash
         run: |
           if [ "${{ needs.changes.outputs.frontend }}" != "true" ]; then
             echo "No frontend changes detected, skipping lint and typecheck"
@@ -59,23 +57,23 @@ jobs:
 
       - name: Install dependencies
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm ci
 
       - name: Lint (Biome)
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm run lint -- --error-on-warnings
 
       - name: Typecheck
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm run check:types
 
   test-and-build:
     name: Test & Build (Node ${{ matrix.node-version }})
     needs: [changes, lint]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./web
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +82,7 @@ jobs:
     steps:
       - name: Check for frontend changes
         id: check_changes
+        shell: bash
         run: |
           if [ "${{ needs.changes.outputs.frontend }}" != "true" ]; then
             echo "No frontend changes detected, skipping test and build"
@@ -104,16 +103,20 @@ jobs:
 
       - name: Install dependencies
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm ci
 
       - name: Install Playwright browsers
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npx playwright install --with-deps chromium
 
       - name: Run tests
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm run test:coverage
 
       - name: Build
         if: steps.check_changes.outputs.has_changes == 'true'
+        working-directory: web
         run: npm run build


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixed CI workflows to ensure all status checks are always reported to GitHub, even when no relevant files are changed, preventing PRs from being blocked by branch protection rules that require these checks.

# Problem

The CI workflows used  filters in the  trigger to conditionally run workflows based on file changes. This created an inconsistency with GitHub's branch protection rules:

1. **Missing status checks**: When a PR didn't touch backend/frontend files, workflows didn't trigger at all, so no status was posted
2. **Matrix jobs not created**: When parent jobs were conditionally skipped with , GitHub didn't create matrix job instances (e.g., "Test & Build (Node 20)", "Test & Build (Node 22)"), leaving them in "Expected" state
3. **Merge failures**: On push to main, the  action failed because the repository wasn't checked out first
4. **PR blocking**: Branch protection rules required these checks, but they never appeared, forcing manual bypasses to merge PRs

# Solution

Refactored both  and  to use a pattern that ensures all jobs always run and report status:

1. **Removed  filters** from  and  triggers - workflows now always trigger
2. **Added  job** using  to detect relevant file changes (with  first to fix merge-to-main failures)
3. **Removed job-level  conditions** - all jobs (including matrix jobs) are always created
4. **Added conditional step execution** - each job has a check step that always runs, then all subsequent steps are conditionally executed based on detected changes
5. **Fixed yamllint errors** - added document start markers and fixed line length violations

This ensures:
- All jobs always exist and report status to GitHub (Success, Failure, or Skipped)
- When no relevant files are changed, jobs complete successfully after the check step
- When relevant files are changed, jobs run normally
- Matrix jobs are always created and report status individually
- PRs can merge without bypassing branch protection rules

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)