### PR TITLE
chore: Don't run CI workflows for release tags

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -4,7 +4,6 @@ name: CI Backend
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]

--- a/.github/workflows/ci-frontend.yaml
+++ b/.github/workflows/ci-frontend.yaml
@@ -4,7 +4,6 @@ name: CI Frontend
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Remove tag triggers from CI workflows to prevent unnecessary CI runs when creating release tags.

# Problem

CI workflows for both backend and frontend were configured to run on release tag pushes (v*). This causes unnecessary CI runs when creating release tags, which typically don't require linting or testing since the code has already been validated through the normal PR process.

# Solution

Removed the  trigger from both  and  workflows. CI will now only run on pushes to main branch and pull requests, not on tag creation.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)