### PR TITLE
Fix: Update demo link in README to direct users to login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## Demo
 
-Try Bookcard online at [https://demo.bookcard.io/](https://demo.bookcard.io/)
+Try Bookcard online at [https://demo.bookcard.io/login](https://demo.bookcard.io/login)
 
 **Demo credentials:**
 - Username: `demo`


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Updates the demo link in README to point directly to the login page instead of the root URL, making it easier for users to access the demo.

# Problem

The demo link in the README was pointing to the root URL (), which may not be the most direct path for users trying to access the demo. Users would need to navigate to the login page manually.

# Solution

Updated the demo link in README.md to point directly to the login page (), providing a more direct path for users to access the demo.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)