### PR TITLE
Fix: Update GitHub Actions workflow to include alias updates during documentation deployment

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         run: |
-          uv run --frozen mike deploy \
+          uv run --frozen mike deploy --update-aliases \
             ${{ steps.version.outputs.version }} latest
           uv run --frozen mike set-default latest
 


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Updates the GitHub Actions documentation deployment workflow to include the `--update-aliases` flag when deploying with mike, ensuring version aliases are properly maintained during documentation deployments.

# Problem

The documentation deployment workflow was missing the `--update-aliases` flag when running `mike deploy`, which could cause version aliases to become stale or inconsistent after deployments.

# Solution

Added the `--update-aliases` flag to the `mike deploy` command in the GitHub Actions workflow (line 76 of `.github/workflows/deploy-docs.yaml`). This ensures that when deploying a new version, all existing aliases are properly updated to point to the correct version.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)