### PR TITLE
Fix book cover images returning 404 - add missing API route handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,7 +189,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-cover/
+/cover/
 
 # Translations
 *.mo

--- a/web/src/app/api/books/[id]/cover/route.ts
+++ b/web/src/app/api/books/[id]/cover/route.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { type NextRequest, NextResponse } from "next/server";
+import { getOptionalClient } from "@/services/http/routeHelpers";
+
+/**
+ * GET /api/books/[id]/cover
+ *
+ * Proxies request to get book cover image.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { client, error } = getOptionalClient(request);
+
+    if (error) {
+      return error;
+    }
+
+    const { id } = await params;
+
+    const response = await client.request(`/books/${id}/cover`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      // If 404, just return 404
+      if (response.status === 404) {
+        return new NextResponse(null, { status: 404 });
+      }
+
+      const data = await response
+        .json()
+        .catch(() => ({ detail: "Failed to fetch cover" }));
+      return NextResponse.json(
+        { detail: data.detail || "Failed to fetch cover" },
+        { status: response.status },
+      );
+    }
+
+    // Get the file content
+    const blob = await response.blob();
+    const contentType = response.headers.get("content-type") || "image/jpeg";
+
+    // Create response with file
+    const fileResponse = new NextResponse(blob, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=86400, immutable", // Cache for 1 day
+      },
+    });
+
+    return fileResponse;
+  } catch (error) {
+    console.error("Cover fetch error:", error);
+    return NextResponse.json(
+      { detail: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/books/staged/[id]/cover/route.ts
+++ b/web/src/app/api/books/staged/[id]/cover/route.ts
@@ -1,0 +1,65 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { type NextRequest, NextResponse } from "next/server";
+import { getAuthenticatedClient } from "@/services/http/routeHelpers";
+
+/**
+ * GET /api/books/staged/[id]/cover
+ *
+ * Proxies request to get a staged book's cover picture.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { client, error } = getAuthenticatedClient(request);
+
+    if (error) {
+      return error;
+    }
+
+    const { id } = await params;
+
+    const response = await client.request(`/books/staged/${id}/cover`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      const data = await response.json();
+      return NextResponse.json(
+        { detail: data.detail || "Failed to fetch cover picture" },
+        { status: response.status },
+      );
+    }
+
+    // Return the file response
+    const blob = await response.blob();
+    return new NextResponse(blob, {
+      headers: {
+        "Content-Type": response.headers.get("Content-Type") || "image/jpeg",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        detail:
+          error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes 404 errors when accessing book cover images by adding missing Next.js API route handlers and fixing .gitignore to properly track the cover route directory.

# Problem

Users reported that accessing book cover images via  was returning 404 errors. The backend FastAPI service had the route implemented, but the Next.js frontend was missing the corresponding API route handler to proxy requests to the backend. Additionally, the  file had a generic  pattern that was unintentionally ignoring the new route handler directory, preventing it from being tracked by git.

# Solution

1. **Added missing API route handlers:**
   - Created  to proxy GET requests for book cover images
   - Created  to proxy GET requests for staged book cover images
   - Both handlers use the existing HTTP client helpers to authenticate and proxy requests to the backend

2. **Fixed .gitignore:**
   - Changed  to  to only ignore a  directory at the repository root (used for test coverage reports)
   - This allows nested  directories like  to be properly tracked by git

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)