### PR TITLE
chore: add commented backend port expose hint

### DIFF
--- a/infra/docker-compose.dev.yaml
+++ b/infra/docker-compose.dev.yaml
@@ -71,6 +71,9 @@ services:
       - .env
     ports:
       - "3000:3000"
+      # Uncomment this if you want to expose the backend port
+      # e.g. for API access and/or OPDS
+      # - "8000:8000"
     healthcheck:
       test:
         - CMD-SHELL

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -66,6 +66,9 @@ services:
       - .env
     ports:
       - "3000:3000"
+      # Uncomment this if you want to expose the backend port
+      # e.g. for API access and/or OPDS
+      # - "8000:8000"
     healthcheck:
       test:
         - CMD-SHELL


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  Add short, yamllint-compliant comments (and a commented port mapping) showing how to expose the backend port (e.g., for API/OPDS access) in both dev and prod docker-compose files.

# Problem

`yamllint` was failing due to an over-80-char comment line, and it wasn’t obvious how to expose the backend port for OPDS/API use.

# Solution

Split the long comment into multiple shorter lines and include the commented `8000:8000` port mapping in both compose files.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)
