### PR TITLE
Switch docker-compose image default to Docker Hub

### DIFF
--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   bookcard:
-    image: ghcr.io/bookcard-io/bookcard:latest
+    image: bookcard/bookcard:latest # or `ghcr.io/bookcard-io/bookcard:latest`
     build:
       context: ..
       dockerfile: infra/Dockerfile


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:
  * Default  to pull  from Docker Hub, while documenting  as an alternative.

# Problem

The default compose image was GHCR-only, which can be less convenient for users who expect Docker Hub by default.

# Solution

Switch the default image reference to Docker Hub and keep the GHCR image as a commented alternative for clarity.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)
