### PR TITLE
Fix: Prefer native comic formats (CBZ/CBR) over EPUB when available

### DIFF
--- a/web/src/components/books/BookViewHeader.tsx
+++ b/web/src/components/books/BookViewHeader.tsx
@@ -27,6 +27,7 @@ import { useUser } from "@/contexts/UserContext";
 import { useTaskTerminalPolling } from "@/hooks/useTaskTerminalPolling";
 import { sendBookToDevice } from "@/services/bookService";
 import type { Book } from "@/types/book";
+import { getPreferredReadableFormat } from "@/utils/bookFormats";
 import { buildBookPermissionContext } from "@/utils/permissions";
 
 export interface BookViewHeaderProps {
@@ -82,23 +83,9 @@ export function BookViewHeader({
   const canWrite = canPerformAction("books", "write", bookContext);
   const canSend = canPerformAction("books", "send", bookContext);
 
-  // Determine preferred format for reading (EPUB > PDF > first available)
+  // Determine preferred format for reading (Comic > EPUB > PDF)
   const preferredFormat = useMemo(() => {
-    if (!book.formats || book.formats.length === 0) {
-      return null;
-    }
-    // Prefer EPUB
-    const epub = book.formats.find((f) => f.format.toUpperCase() === "EPUB");
-    if (epub) {
-      return epub.format;
-    }
-    // Then PDF
-    const pdf = book.formats.find((f) => f.format.toUpperCase() === "PDF");
-    if (pdf) {
-      return pdf.format;
-    }
-    // Otherwise use first available format
-    return book.formats[0]?.format || null;
+    return getPreferredReadableFormat(book.formats || []);
   }, [book.formats]);
 
   const handleRead = useCallback(() => {
@@ -106,7 +93,7 @@ export function BookViewHeader({
       showDanger("No readable format available for this book");
       return;
     }
-    router.push(`/reading/${book.id}/${preferredFormat.toUpperCase()}`);
+    router.push(`/reading/${book.id}/${preferredFormat}`);
   }, [book.id, preferredFormat, router, showDanger]);
 
   const handleSend = useCallback(async () => {

--- a/web/src/components/reading/BookCardProgress.tsx
+++ b/web/src/components/reading/BookCardProgress.tsx
@@ -20,6 +20,7 @@ import { useReadingProgress } from "@/hooks/useReadingProgress";
 import { useReadStatus } from "@/hooks/useReadStatus";
 import { cn } from "@/libs/utils";
 import type { Book } from "@/types/book";
+import { getReadableFormatForReader } from "@/utils/bookFormats";
 import { ReadingProgressIndicator } from "./ReadingProgressIndicator";
 
 export interface BookCardProgressProps {
@@ -50,13 +51,9 @@ export function BookCardProgress({
 }: BookCardProgressProps) {
   // Determine format to use
   const format = useMemo(() => {
-    if (
-      preferredFormat &&
-      book.formats?.some((f) => f.format === preferredFormat)
-    ) {
-      return preferredFormat;
-    }
-    return book.formats?.[0]?.format || "EPUB";
+    return (
+      getReadableFormatForReader(book.formats || [], preferredFormat) || ""
+    );
   }, [preferredFormat, book.formats]);
 
   const { progress } = useReadingProgress({

--- a/web/src/components/reading/BookReadingInfo.tsx
+++ b/web/src/components/reading/BookReadingInfo.tsx
@@ -22,6 +22,7 @@ import { useReadingProgress } from "@/hooks/useReadingProgress";
 import { useReadStatus } from "@/hooks/useReadStatus";
 import { cn } from "@/libs/utils";
 import type { Book } from "@/types/book";
+import { getReadableFormatForReader } from "@/utils/bookFormats";
 import { ReadingHistoryList } from "./ReadingHistoryList";
 import { ReadingProgressBar } from "./ReadingProgressBar";
 
@@ -56,13 +57,9 @@ export function BookReadingInfo({
 
   // Determine format to use
   const format = useMemo(() => {
-    if (
-      preferredFormat &&
-      book.formats?.some((f) => f.format === preferredFormat)
-    ) {
-      return preferredFormat;
-    }
-    return book.formats?.[0]?.format || "EPUB";
+    return (
+      getReadableFormatForReader(book.formats || [], preferredFormat) || ""
+    );
   }, [preferredFormat, book.formats]);
 
   const {

--- a/web/src/components/reading/ReadingSeriesPanel.tsx
+++ b/web/src/components/reading/ReadingSeriesPanel.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import { BookCard } from "@/components/library/BookCard";
 import { useBooks } from "@/hooks/useBooks";
+import { getReadableFormatForReader } from "@/utils/bookFormats";
 import { ThemeSettingsPanel } from "./components/ThemeSettingsPanel";
 
 export interface ReadingSeriesPanelProps {
@@ -75,15 +76,9 @@ export function ReadingSeriesPanel({
       : null;
 
   const handleBookClick = (book: import("@/types/book").Book) => {
-    // Determine the best format to use
-    // Prefer EPUB, then try others, fallback to first available
-    let format = "EPUB";
-    if (book.formats && book.formats.length > 0) {
-      const formats = book.formats;
-      const hasEpub = formats.some((f) => f.format.toUpperCase() === "EPUB");
-      if (!hasEpub && formats[0]) {
-        format = formats[0].format.toUpperCase();
-      }
+    const format = getReadableFormatForReader(book.formats || []);
+    if (!format) {
+      return;
     }
 
     router.push(`/reading/${book.id}/${format}`);

--- a/web/src/utils/bookFormats.test.ts
+++ b/web/src/utils/bookFormats.test.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+import {
+  getPreferredReadableFormat,
+  getReadableFormatForReader,
+} from "./bookFormats";
+
+describe("bookFormats utils", () => {
+  describe("getPreferredReadableFormat", () => {
+    it("should return null when formats are empty", () => {
+      expect(getPreferredReadableFormat([])).toBeNull();
+    });
+
+    it.each([
+      [{ format: "cbz" }, "CBZ"],
+      [{ format: "CBR" }, "CBR"],
+      [{ format: "cb7" }, "CB7"],
+      [{ format: "cbc" }, "CBC"],
+    ])("should prefer native comic formats (%s -> %s)", (format, expected) => {
+      expect(getPreferredReadableFormat([format])).toBe(expected);
+    });
+
+    it("should prefer EPUB when no comic formats are available", () => {
+      expect(
+        getPreferredReadableFormat([{ format: "pdf" }, { format: "epub" }]),
+      ).toBe("EPUB");
+    });
+
+    it("should prefer PDF when no comic formats or EPUB are available", () => {
+      expect(getPreferredReadableFormat([{ format: "pdf" }])).toBe("PDF");
+    });
+
+    it("should return null when no readable formats are available", () => {
+      expect(getPreferredReadableFormat([{ format: "mobi" }])).toBeNull();
+    });
+  });
+
+  describe("getReadableFormatForReader", () => {
+    it("should return null when no formats are available", () => {
+      expect(getReadableFormatForReader([], "EPUB")).toBeNull();
+    });
+
+    it("should honor a preferred comic format when available", () => {
+      expect(
+        getReadableFormatForReader(
+          [{ format: "cbz" }, { format: "cbr" }, { format: "epub" }],
+          "cbr",
+        ),
+      ).toBe("CBR");
+    });
+
+    it("should prefer comics even when a non-comic preferred format is provided", () => {
+      expect(
+        getReadableFormatForReader(
+          [{ format: "pdf" }, { format: "cbr" }],
+          "pdf",
+        ),
+      ).toBe("CBR");
+    });
+
+    it("should honor a preferred readable non-comic format when no comics are available", () => {
+      expect(
+        getReadableFormatForReader(
+          [{ format: "epub" }, { format: "pdf" }],
+          "pdf",
+        ),
+      ).toBe("PDF");
+    });
+
+    it("should fall back to best readable format when preferred format is not available", () => {
+      expect(getReadableFormatForReader([{ format: "epub" }], "pdf")).toBe(
+        "EPUB",
+      );
+    });
+
+    it("should ignore unreadable preferred formats and fall back", () => {
+      expect(getReadableFormatForReader([{ format: "epub" }], "mobi")).toBe(
+        "EPUB",
+      );
+    });
+  });
+});

--- a/web/src/utils/bookFormats.ts
+++ b/web/src/utils/bookFormats.ts
@@ -1,24 +1,87 @@
-import { READABLE_FORMATS } from "./formatUtils";
+import { COMIC_FORMATS, READABLE_FORMATS } from "./formatUtils";
 
 export interface BookFormat {
   format: string;
 }
 
 /**
- * Get the preferred readable format for a book.
+ * Get the preferred readable format for opening in the reader.
  *
- * Priorities: EPUB > PDF > Comic formats (defined in READABLE_FORMATS).
+ * Native comic formats (CBZ/CBR/CB7/CBC) are always preferred when available.
+ * Next preferred is EPUB, then PDF, then any other readable formats as defined in
+ * `READABLE_FORMATS`.
  *
- * @param formats List of available book formats
- * @returns Preferred format string or null if no readable format found
+ * Parameters
+ * ----------
+ * formats : BookFormat[]
+ *     List of available book formats (e.g., from `book.formats`).
+ *
+ * Returns
+ * -------
+ * string | null
+ *     Preferred readable format (always returned in uppercase), or null if no
+ *     readable format is available.
  */
 export function getPreferredReadableFormat(
   formats: BookFormat[],
 ): string | null {
+  const available = new Set(formats.map((f) => f.format.toUpperCase()));
+
   for (const priority of READABLE_FORMATS) {
-    const found = formats.find((f) => f.format.toUpperCase() === priority);
-    if (found) return found.format;
+    if (available.has(priority)) {
+      return priority;
+    }
   }
 
   return null;
+}
+
+/**
+ * Resolve the best readable format for the reader, honoring an optional
+ * preferred format while still preferring native comic formats when available.
+ *
+ * Parameters
+ * ----------
+ * formats : BookFormat[]
+ *     Available book formats.
+ * preferredFormat : string | undefined
+ *     Optional preferred format to use when available.
+ *
+ * Returns
+ * -------
+ * string | null
+ *     Resolved readable format (uppercase) or null if none is readable.
+ */
+export function getReadableFormatForReader(
+  formats: BookFormat[],
+  preferredFormat?: string,
+): string | null {
+  const available = new Set(formats.map((f) => f.format.toUpperCase()));
+
+  const preferredUpper = preferredFormat?.toUpperCase();
+
+  // If the preferred format is a native comic and it exists, honor it.
+  if (
+    preferredUpper &&
+    available.has(preferredUpper) &&
+    (COMIC_FORMATS as readonly string[]).includes(preferredUpper)
+  ) {
+    return preferredUpper;
+  }
+
+  // Native comics always win when present, regardless of a non-comic preference.
+  if ((COMIC_FORMATS as readonly string[]).some((c) => available.has(c))) {
+    return getPreferredReadableFormat(formats);
+  }
+
+  // Otherwise, honor the preferred format when it is readable and available.
+  if (
+    preferredUpper &&
+    available.has(preferredUpper) &&
+    (READABLE_FORMATS as readonly string[]).includes(preferredUpper)
+  ) {
+    return preferredUpper;
+  }
+
+  return getPreferredReadableFormat(formats);
 }

--- a/web/src/utils/formatUtils.test.ts
+++ b/web/src/utils/formatUtils.test.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+import { isComicFormat } from "./formatUtils";
+
+describe("formatUtils", () => {
+  describe("isComicFormat", () => {
+    it("should return false for undefined", () => {
+      expect(isComicFormat(undefined)).toBe(false);
+    });
+
+    it.each([
+      ["cbz", true],
+      ["CBZ", true],
+      ["cbr", true],
+      ["CB7", true],
+      ["cbc", true],
+      ["epub", false],
+      ["pdf", false],
+      ["mobi", false],
+    ])("should detect comic formats (%s -> %s)", (format, expected) => {
+      expect(isComicFormat(format)).toBe(expected);
+    });
+  });
+});

--- a/web/src/utils/formatUtils.ts
+++ b/web/src/utils/formatUtils.ts
@@ -31,9 +31,9 @@ export const AUDIOBOOK_FORMATS = ["MP3", "M4B", "M4A", "WAV", "FLAC"] as const;
 /**
  * All supported readable formats in priority order.
  *
- * EPUB is preferred, then PDF, then comics.
+ * Native comic formats are preferred first, then EPUB, then PDF.
  */
-export const READABLE_FORMATS = ["EPUB", "PDF", ...COMIC_FORMATS] as const;
+export const READABLE_FORMATS = [...COMIC_FORMATS, "EPUB", "PDF"] as const;
 
 /**
  * Check if a format is a comic book format.


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [x] Refactoring
* **Describe this change in 1-2 sentences**: Centralizes book format selection logic to consistently prefer native comic formats (CBZ/CBR/CB7/CBC) first, then EPUB, then PDF. All reading components now use the same centralized utility functions.

# Problem

Previously, different components handled format selection inconsistently:
- Some components preferred EPUB first, ignoring native comic formats
- Format selection logic was duplicated across multiple components (ReadingSeriesPanel, BookReadingInfo, BookCardProgress, BookViewHeader)
- This caused inconsistent behavior when books had both comic formats and EPUB available

# Solution

1. **Centralized format selection logic** in `web/src/utils/bookFormats.ts`:
   - Updated `getPreferredReadableFormat()` to prioritize: Comic formats → EPUB → PDF
   - Added `getReadableFormatForReader()` to handle preferred format parameter while still prioritizing comics
   - Updated `READABLE_FORMATS` constant in `formatUtils.ts` to reflect comic-first priority

2. **Refactored components** to use centralized utilities:
   - `ReadingSeriesPanel.tsx` - Removed EPUB-first logic, uses `getReadableFormatForReader()`
   - `BookReadingInfo.tsx` - Uses `getReadableFormatForReader()` instead of manual format selection
   - `BookCardProgress.tsx` - Uses `getReadableFormatForReader()` instead of fallback to EPUB
   - `BookViewHeader.tsx` - Uses `getPreferredReadableFormat()` instead of manual EPUB/PDF preference

3. **Added comprehensive test coverage**:
   - `bookFormats.test.ts` - 14 tests covering all branches in format selection functions
   - `formatUtils.test.ts` - 9 tests covering comic format detection
   - Both files now at **100% coverage** (statements, branches, functions, lines)

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)