### PR TITLE
Add loading spinner to Add Books button

### DIFF
--- a/web/src/components/library/widgets/AddBooksButton.tsx
+++ b/web/src/components/library/widgets/AddBooksButton.tsx
@@ -15,6 +15,7 @@
 
 "use client";
 
+import { FaPlus, FaSpinner } from "react-icons/fa";
 import { useUser } from "@/contexts/UserContext";
 import { cn } from "@/libs/utils";
 
@@ -95,10 +96,17 @@ export function AddBooksButton({
         disabled={!canCreate || isUploading}
         aria-label="Add books"
       >
-        <i
-          className="pi pi-plus flex-shrink-0 text-[var(--color-text-primary-a0)]"
-          aria-hidden="true"
-        />
+        {isUploading ? (
+          <FaSpinner
+            className="flex-shrink-0 animate-spin text-[var(--color-text-primary-a0)]"
+            aria-hidden="true"
+          />
+        ) : (
+          <FaPlus
+            className="flex-shrink-0 text-[var(--color-text-primary-a0)]"
+            aria-hidden="true"
+          />
+        )}
         <span className="leading-none">
           {isUploading ? "Uploading..." : "Add Books"}
         </span>


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Replaces PrimeIcons with react-icons for consistency and adds a loading spinner to the Add Books button when uploads are in progress.

# Problem

The Add Books button used PrimeIcons (pi pi-plus) which was inconsistent with the rest of the codebase that uses react-icons. Additionally, there was no visual feedback when an upload was in progress, making it unclear to users that the button was processing their request.

# Solution

- Replaced PrimeIcons plus icon with FaPlus from react-icons/fa for consistency
- Added FaSpinner icon that appears with animate-spin class when isUploading is true
- The spinner provides clear visual feedback during upload operations

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)