### PR TITLE
Fix foreign key violation when deleting books with ingest history

### DIFF
--- a/web/src/hooks/useDeleteConfirmation.ts
+++ b/web/src/hooks/useDeleteConfirmation.ts
@@ -115,8 +115,21 @@ export function useDeleteConfirmation({
         });
 
         if (!response.ok) {
-          const data = (await response.json()) as { detail?: string };
-          const errorMsg = data.detail || "Failed to delete book";
+          let errorMsg = "Failed to delete book";
+          try {
+            const data = (await response.json()) as { detail?: string };
+            errorMsg = data.detail || errorMsg;
+          } catch {
+            // Non-JSON error response (e.g., plain text / HTML)
+            try {
+              const text = await response.text();
+              if (text) {
+                errorMsg = text;
+              }
+            } catch {
+              // Ignore secondary parse failures; keep default message
+            }
+          }
           setError(errorMsg);
           onError?.(errorMsg);
           return;


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes a foreign key constraint violation when deleting books that have associated ingest history records. The deletion process now properly handles dependent records (IngestAudit and IngestRetry) before deleting IngestHistory records.

# Problem

When deleting a book that had ingest history records, the deletion would fail with a foreign key constraint violation:

```
psycopg.errors.ForeignKeyViolation: update or delete on table "ingest_history" violates foreign key constraint "ingest_audit_history_id_fkey" on table "ingest_audit"
DETAIL:  Key (id)=(34) is still referenced from table "ingest_audit".
```

This occurred because the code attempted to delete `IngestHistory` records before deleting the dependent `IngestAudit` and `IngestRetry` records that reference them via foreign keys.

# Solution

1. **Added proper deletion ordering**: Created a new `_delete_ingest_associations()` method that:
   - First queries for all `IngestHistory` records associated with the book
   - Deletes all `IngestRetry` records that reference those history IDs
   - Deletes all `IngestAudit` records that reference those history IDs
   - Only then proceeds to delete the `IngestHistory` records

2. **Improved error handling**: 
   - Changed exception handling from catching generic `Exception` to specific `SQLAlchemyError` (following DRY/SRP principles)
   - Enhanced frontend error parsing to handle non-JSON error responses gracefully

3. **Fixed type checking issues**: Used `sqlmodel.col()` wrapper for SQLModel field queries to satisfy type checkers when using `.in_()` method

4. **Updated tests**: Modified test expectations to account for the new deletion steps and proper exception types

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)