### PR TITLE
Add cover technical details to fetch metadata screen

### DIFF
--- a/web/src/app/api/metadata/probe-image/route.test.ts
+++ b/web/src/app/api/metadata/probe-image/route.test.ts
@@ -1,0 +1,129 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type ProbeMock = ReturnType<typeof vi.fn>;
+
+/**
+ * Create a minimal NextRequest-like object for API route testing.
+ *
+ * Parameters
+ * ----------
+ * url : string
+ *     Full request URL.
+ */
+function createRequest(url: string): NextRequest {
+  return {
+    nextUrl: new URL(url),
+  } as unknown as NextRequest;
+}
+
+describe("GET /api/metadata/probe-image", () => {
+  let probeMock: ProbeMock;
+
+  beforeEach(() => {
+    vi.resetModules();
+    probeMock = vi.fn();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.doMock("@/services/metadata/imageProbeService", () => ({
+      ImageProbeService: class ImageProbeServiceMock {
+        probe = probeMock;
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return 400 when url param is missing", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(
+      createRequest("http://localhost/api/metadata/probe-image"),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      detail: "Missing url parameter",
+    });
+  });
+
+  it("should return probed metadata on success", async () => {
+    probeMock.mockResolvedValue({
+      size: 123,
+      mimeType: "image/jpeg",
+      extension: "jpg",
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET(
+      createRequest(
+        "http://localhost/api/metadata/probe-image?url=https%3A%2F%2Fexample.com%2Fimage.jpg",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      size: 123,
+      mimeType: "image/jpeg",
+      extension: "jpg",
+    });
+  });
+
+  it("should map ImageProbeError to its status code", async () => {
+    const { GET } = await import("./route");
+    const { ImageProbeError } = await import("@/types/imageProbe");
+    probeMock.mockRejectedValue(new ImageProbeError("Forbidden URL", 400));
+    const res = await GET(
+      createRequest(
+        "http://localhost/api/metadata/probe-image?url=http%3A%2F%2F127.0.0.1%2Fimage.jpg",
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ detail: "Forbidden URL" });
+  });
+
+  it("should treat TypeError as invalid URL", async () => {
+    probeMock.mockRejectedValue(new TypeError("bad url"));
+
+    const { GET } = await import("./route");
+    const res = await GET(
+      createRequest("http://localhost/api/metadata/probe-image?url=not-a-url"),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ detail: "Invalid URL" });
+  });
+
+  it("should return 500 on unexpected errors", async () => {
+    probeMock.mockRejectedValue(new Error("boom"));
+
+    const { GET } = await import("./route");
+    const res = await GET(
+      createRequest(
+        "http://localhost/api/metadata/probe-image?url=https%3A%2F%2Fexample.com%2Fimage.jpg",
+      ),
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      detail: "Failed to probe image",
+    });
+  });
+});

--- a/web/src/app/api/metadata/probe-image/route.ts
+++ b/web/src/app/api/metadata/probe-image/route.ts
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { type NextRequest, NextResponse } from "next/server";
+import { ImageProbeService } from "@/services/metadata/imageProbeService";
+import { ImageProbeError, InvalidUrlError } from "@/types/imageProbe";
+
+export const runtime = "nodejs";
+
+const imageProbeService = new ImageProbeService({
+  config: {
+    followRedirects: false,
+    timeoutMs: 10_000,
+    maxSizeBytes: 50 * 1024 * 1024,
+  },
+});
+
+/**
+ * GET /api/metadata/probe-image
+ *
+ * Probes an external image URL for its size (Content-Length),
+ * MIME type, and inferred extension.
+ * Used to bypass CORS restrictions on the client side.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const url = searchParams.get("url");
+
+    if (!url) {
+      return jsonError("Missing url parameter", 400);
+    }
+
+    const result = await imageProbeService.probe(url);
+    return NextResponse.json(result);
+  } catch (error) {
+    if (error instanceof ImageProbeError) {
+      return jsonError(error.message, error.statusCode);
+    }
+
+    // URL parsing can throw TypeError depending on runtime.
+    if (error instanceof TypeError) {
+      const invalid = new InvalidUrlError("Invalid URL", error);
+      return jsonError(invalid.message, invalid.statusCode);
+    }
+
+    console.warn("Image probe error:", error);
+    return jsonError("Failed to probe image", 500);
+  }
+}
+
+function jsonError(detail: string, status: number) {
+  return NextResponse.json({ detail }, { status });
+}

--- a/web/src/components/metadata/MetadataFieldSelectionDrawer.tsx
+++ b/web/src/components/metadata/MetadataFieldSelectionDrawer.tsx
@@ -16,6 +16,7 @@
 "use client";
 
 import { Button } from "@/components/forms/Button";
+import { useImageMetadata } from "@/hooks/useImageMetadata";
 import type { MetadataRecord } from "@/hooks/useMetadataSearchStream";
 import { METADATA_FIELDS, type MetadataFieldKey } from "./metadataFields";
 
@@ -48,6 +49,8 @@ export function MetadataFieldSelectionDrawer({
   onCancel,
   isAnimatingOut,
 }: MetadataFieldSelectionDrawerProps) {
+  const { sizeKiB, dimensions, extension } = useImageMetadata(record.cover_url);
+
   return (
     <div
       className={`overflow-hidden border-surface-a20 border-t pt-3 ${
@@ -77,6 +80,17 @@ export function MetadataFieldSelectionDrawer({
             <div className="shrink-0">
               {METADATA_FIELDS.find((f) => f.key === "cover")?.getValue(record)}
             </div>
+            {(sizeKiB !== null || dimensions !== null) && (
+              <div className="flex flex-col items-center text-text-a40 text-xs">
+                {sizeKiB !== null && <span>{sizeKiB} KiB</span>}
+                {dimensions !== null && (
+                  <span>
+                    {dimensions.width} x {dimensions.height}
+                  </span>
+                )}
+                {extension && <span>{extension}</span>}
+              </div>
+            )}
           </div>
         )}
 

--- a/web/src/hooks/useImageMetadata.ts
+++ b/web/src/hooks/useImageMetadata.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  BrowserImageDimensionLoader,
+  ImageMetadataService,
+  ProxyImageMetadataFetcher,
+} from "@/services/imageMetadata";
+import type {
+  ImageDimensionLoader,
+  ImageMetadata,
+  ImageMetadataFetcher,
+} from "@/types/imageMetadata";
+import { EMPTY_IMAGE_METADATA } from "@/utils/imageMetadata";
+
+export {
+  BrowserImageDimensionLoader,
+  ImageMetadataService,
+  ProxyImageMetadataFetcher,
+} from "@/services/imageMetadata";
+export type {
+  ImageDimensionLoader,
+  ImageDimensions,
+  ImageMetadata,
+  ImageMetadataFetcher,
+  RawImageMetadata,
+} from "@/types/imageMetadata";
+
+/**
+ * Options for configuring `useImageMetadata`.
+ */
+export interface UseImageMetadataOptions {
+  fetcher?: ImageMetadataFetcher;
+  loader?: ImageDimensionLoader;
+  service?: ImageMetadataService;
+}
+
+const DEFAULT_FETCHER = new ProxyImageMetadataFetcher();
+const DEFAULT_LOADER = new BrowserImageDimensionLoader();
+const DEFAULT_SERVICE = new ImageMetadataService(
+  DEFAULT_FETCHER,
+  DEFAULT_LOADER,
+);
+
+/**
+ * Hook to probe image metadata (size, dimensions, type) in a best-effort manner.
+ *
+ * This hook is intentionally thin:
+ * - Infrastructure concerns are delegated to injected dependencies.
+ * - Orchestration lives in `ImageMetadataService`.
+ *
+ * Parameters
+ * ----------
+ * url : string or null or undefined
+ *     Image URL to probe.
+ * options : UseImageMetadataOptions, optional
+ *     Dependency overrides for testability and extensibility.
+ *
+ * Returns
+ * -------
+ * ImageMetadata
+ *     Normalized metadata object (fields null if unavailable).
+ */
+export function useImageMetadata(
+  url: string | null | undefined,
+  options: UseImageMetadataOptions = {},
+): ImageMetadata {
+  const [metadata, setMetadata] = useState<ImageMetadata>(EMPTY_IMAGE_METADATA);
+
+  const service = useMemo(() => {
+    if (options.service) return options.service;
+
+    // Keep the default service stable unless overrides are provided.
+    if (!options.fetcher && !options.loader) return DEFAULT_SERVICE;
+
+    return new ImageMetadataService(
+      options.fetcher ?? DEFAULT_FETCHER,
+      options.loader ?? DEFAULT_LOADER,
+    );
+  }, [options.fetcher, options.loader, options.service]);
+
+  useEffect(() => {
+    if (!url) {
+      setMetadata(EMPTY_IMAGE_METADATA);
+      return;
+    }
+
+    let isActive = true;
+    const abortController = new AbortController();
+
+    // Avoid showing stale metadata when URL changes.
+    setMetadata(EMPTY_IMAGE_METADATA);
+
+    void (async () => {
+      const result = await service.probe(url, {
+        signal: abortController.signal,
+      });
+      if (isActive && !abortController.signal.aborted) {
+        setMetadata(result);
+      }
+    })();
+
+    return () => {
+      isActive = false;
+      abortController.abort();
+    };
+  }, [service, url]);
+
+  return metadata;
+}

--- a/web/src/services/imageMetadata.ts
+++ b/web/src/services/imageMetadata.ts
@@ -1,0 +1,155 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  ImageDimensionLoader,
+  ImageDimensions,
+  ImageMetadata,
+  ImageMetadataFetcher,
+  RawImageMetadata,
+} from "@/types/imageMetadata";
+import { combineImageMetadata } from "@/utils/imageMetadata";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Fetcher that probes image metadata through an internal proxy endpoint.
+ */
+export class ProxyImageMetadataFetcher implements ImageMetadataFetcher {
+  private readonly endpoint: string;
+  private readonly fetchImpl: FetchLike;
+
+  /**
+   * Parameters
+   * ----------
+   * params : object, optional
+   *     Constructor parameters.
+   * params.endpoint : string, optional
+   *     Proxy endpoint to call (default: "/api/metadata/probe-image").
+   * params.fetchImpl : callable, optional
+   *     Fetch implementation for DI/testing (default: global fetch).
+   */
+  constructor(params: { endpoint?: string; fetchImpl?: FetchLike } = {}) {
+    this.endpoint = params.endpoint ?? "/api/metadata/probe-image";
+    this.fetchImpl = params.fetchImpl ?? fetch;
+  }
+
+  async fetchMetadata(
+    url: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<RawImageMetadata> {
+    const proxyUrl = `${this.endpoint}?url=${encodeURIComponent(url)}`;
+    const response = await this.fetchImpl(proxyUrl, {
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return (await response.json()) as RawImageMetadata;
+  }
+}
+
+/**
+ * Loader that uses the browser Image API to determine natural dimensions.
+ */
+export class BrowserImageDimensionLoader implements ImageDimensionLoader {
+  async loadDimensions(
+    url: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ImageDimensions | null> {
+    return await new Promise<ImageDimensions | null>((resolve) => {
+      const img = new Image();
+      let settled = false;
+
+      const cleanup = () => {
+        img.onload = null;
+        img.onerror = null;
+        // Clearing src helps cancel/stop some in-flight loads.
+        img.src = "";
+      };
+
+      const settle = (value: ImageDimensions | null) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      };
+
+      const onAbort = () => settle(null);
+
+      if (options?.signal?.aborted) {
+        settle(null);
+        return;
+      }
+
+      options?.signal?.addEventListener("abort", onAbort, { once: true });
+
+      img.onload = () => {
+        options?.signal?.removeEventListener("abort", onAbort);
+        settle({ width: img.naturalWidth, height: img.naturalHeight });
+      };
+
+      img.onerror = () => {
+        options?.signal?.removeEventListener("abort", onAbort);
+        settle(null);
+      };
+
+      img.src = url;
+    });
+  }
+}
+
+/**
+ * Service that combines metadata from a fetcher and a dimension loader.
+ */
+export class ImageMetadataService {
+  constructor(
+    private readonly fetcher: ImageMetadataFetcher,
+    private readonly loader: ImageDimensionLoader,
+  ) {}
+
+  /**
+   * Best-effort probe for image metadata.
+   *
+   * Parameters
+   * ----------
+   * url : string
+   *     Image URL to probe.
+   * options : object, optional
+   *     Optional abort signal forwarded to dependencies.
+   */
+  async probe(
+    url: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ImageMetadata> {
+    const [rawResult, dimsResult] = await Promise.allSettled([
+      this.fetcher.fetchMetadata(url, options),
+      this.loader.loadDimensions(url, options),
+    ]);
+
+    const raw: RawImageMetadata =
+      rawResult.status === "fulfilled" ? rawResult.value : {};
+
+    const dims: ImageDimensions | null =
+      dimsResult.status === "fulfilled" ? dimsResult.value : null;
+
+    return combineImageMetadata(raw, dims);
+  }
+}

--- a/web/src/services/metadata/imageProbeService.test.ts
+++ b/web/src/services/metadata/imageProbeService.test.ts
@@ -1,0 +1,254 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  NotImageError,
+  SSRFError,
+  TooLargeError,
+  UpstreamError,
+} from "@/types/imageProbe";
+
+vi.mock("@/utils/security/ssrf", () => ({
+  validateRemoteHttpUrl: vi.fn(),
+}));
+
+import { validateRemoteHttpUrl } from "@/utils/security/ssrf";
+import { ImageProbeService } from "./imageProbeService";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+type FetchMock = ReturnType<typeof vi.fn<FetchLike>>;
+type ServiceConfig = Partial<
+  NonNullable<ConstructorParameters<typeof ImageProbeService>[0]>["config"]
+>;
+
+/**
+ * Create a Response with headers for probing.
+ *
+ * Parameters
+ * ----------
+ * params : object
+ *     Response parameters.
+ */
+function createProbeResponse(params: {
+  status: number;
+  headers?: Record<string, string>;
+}): Response {
+  return new Response("", {
+    status: params.status,
+    headers: params.headers,
+  });
+}
+
+/**
+ * Create a service with a mocked fetch implementation.
+ *
+ * Parameters
+ * ----------
+ * fetchImpl : FetchMock
+ *     Mock fetch function.
+ * config : object, optional
+ *     Config overrides.
+ */
+function createService(fetchImpl: FetchMock, config?: ServiceConfig) {
+  return new ImageProbeService({
+    fetchImpl,
+    config,
+  });
+}
+
+describe("ImageProbeService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateRemoteHttpUrl).mockImplementation(
+      async (rawUrl: string) => {
+        return new URL(rawUrl);
+      },
+    );
+  });
+
+  it("should call HEAD and return metadata when HEAD succeeds", async () => {
+    const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+      createProbeResponse({
+        status: 200,
+        headers: {
+          "content-length": "123",
+          "content-type": "image/jpeg; charset=utf-8",
+        },
+      }),
+    );
+
+    const service = createService(mockFetch);
+    const result = await service.probe("https://example.com/image.jpg");
+
+    expect(result).toEqual({
+      size: 123,
+      mimeType: "image/jpeg",
+      extension: "jpg",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        method: "HEAD",
+        redirect: "manual",
+        headers: expect.objectContaining({
+          "User-Agent": "BookCard/1.0",
+        }),
+      }),
+    );
+  });
+
+  it("should fallback to Range GET when HEAD fails", async () => {
+    const mockFetch = vi
+      .fn<FetchLike>()
+      .mockResolvedValueOnce(createProbeResponse({ status: 405 }))
+      .mockResolvedValueOnce(
+        createProbeResponse({
+          status: 200,
+          headers: {
+            "content-range": "bytes 0-0/2048",
+            "content-type": "image/png",
+          },
+        }),
+      );
+
+    const service = createService(mockFetch);
+    const result = await service.probe("https://example.com/image.png");
+
+    expect(result).toEqual({
+      size: 2048,
+      mimeType: "image/png",
+      extension: "png",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ method: "HEAD" }),
+    );
+    expect(mockFetch.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Range: "bytes=0-0",
+          "User-Agent": "BookCard/1.0",
+        }),
+      }),
+    );
+  });
+
+  it("should reject redirects when followRedirects is false", async () => {
+    const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+      createProbeResponse({
+        status: 302,
+        headers: {
+          location: "https://internal.local/secret",
+        },
+      }),
+    );
+
+    const service = createService(mockFetch, { followRedirects: false });
+    const promise = service.probe("https://example.com/redirect");
+    await expect(promise).rejects.toBeInstanceOf(UpstreamError);
+    await expect(promise).rejects.toEqual(
+      expect.objectContaining({ statusCode: 400 }),
+    );
+  });
+
+  it("should throw NotImageError when content-type is not an image", async () => {
+    const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+      createProbeResponse({
+        status: 200,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+        },
+      }),
+    );
+
+    const service = createService(mockFetch);
+    await expect(
+      service.probe("https://example.com/index.html"),
+    ).rejects.toBeInstanceOf(NotImageError);
+  });
+
+  it("should throw TooLargeError when size exceeds maxSizeBytes", async () => {
+    const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+      createProbeResponse({
+        status: 200,
+        headers: {
+          "content-length": String(51 * 1024 * 1024),
+          "content-type": "image/jpeg",
+        },
+      }),
+    );
+
+    const service = createService(mockFetch, {
+      maxSizeBytes: 50 * 1024 * 1024,
+    });
+    await expect(
+      service.probe("https://example.com/huge.jpg"),
+    ).rejects.toBeInstanceOf(TooLargeError);
+  });
+
+  it("should map AbortError to UpstreamError 504", async () => {
+    const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+    const mockFetch = vi.fn<FetchLike>().mockRejectedValue(abort);
+
+    const service = createService(mockFetch, { timeoutMs: 1 });
+    await expect(
+      service.probe("https://example.com/image.jpg"),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "UpstreamError",
+        statusCode: 504,
+      }),
+    );
+  });
+
+  it("should preserve SSRF errors from validator", async () => {
+    vi.mocked(validateRemoteHttpUrl).mockRejectedValue(
+      new SSRFError("Forbidden URL"),
+    );
+
+    const mockFetch = vi.fn<FetchLike>();
+    const service = createService(mockFetch);
+
+    await expect(
+      service.probe("http://127.0.0.1/image.jpg"),
+    ).rejects.toBeInstanceOf(SSRFError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("should infer extension from URL when mime is unknown but still image/*", async () => {
+    const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+      createProbeResponse({
+        status: 200,
+        headers: {
+          "content-type": "image/unknown",
+        },
+      }),
+    );
+
+    const service = createService(mockFetch);
+    const result = await service.probe("https://example.com/picture.webp");
+
+    expect(result.extension).toBe("webp");
+    expect(result.mimeType).toBe("image/unknown");
+  });
+});

--- a/web/src/services/metadata/imageProbeService.ts
+++ b/web/src/services/metadata/imageProbeService.ts
@@ -1,0 +1,246 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ImageProbeConfig, ImageProbeResult } from "@/types/imageProbe";
+import {
+  NotImageError,
+  TooLargeError,
+  UpstreamError,
+} from "@/types/imageProbe";
+import {
+  extensionFromMimeType,
+  isImageMimeType,
+  isValidImageExtension,
+  normalizeMimeType,
+} from "@/utils/metadata/mimeTypes";
+import { validateRemoteHttpUrl } from "@/utils/security/ssrf";
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const DEFAULT_CONFIG: ImageProbeConfig = {
+  maxSizeBytes: 50 * 1024 * 1024,
+  timeoutMs: 10_000,
+  allowedSchemes: new Set(["http", "https"]),
+  userAgent: "BookCard/1.0",
+  followRedirects: false,
+};
+
+/**
+ * Service that probes remote images for headers-based metadata.
+ *
+ * It is designed to be safe by default:
+ * - Rejects private/local targets (SSRF mitigation)
+ * - Does not follow redirects (prevents redirect-based SSRF)
+ * - Uses timeouts and avoids downloading full bodies
+ */
+export class ImageProbeService {
+  private readonly config: ImageProbeConfig;
+  private readonly fetchImpl: FetchLike;
+
+  /**
+   * Parameters
+   * ----------
+   * params : object, optional
+   *     Constructor parameters.
+   * params.config : Partial[ImageProbeConfig], optional
+   *     Configuration overrides.
+   * params.fetchImpl : callable, optional
+   *     Fetch implementation for DI/testing (default: global fetch).
+   */
+  constructor(
+    params: { config?: Partial<ImageProbeConfig>; fetchImpl?: FetchLike } = {},
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...(params.config ?? {}) };
+    this.fetchImpl = params.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Probe an image URL for size, mime type, and inferred extension.
+   *
+   * Parameters
+   * ----------
+   * url : string
+   *     Target image URL.
+   *
+   * Returns
+   * -------
+   * ImageProbeResult
+   *     Probed metadata.
+   */
+  async probe(url: string): Promise<ImageProbeResult> {
+    const parsed = await validateRemoteHttpUrl(url, {
+      allowedSchemes: this.config.allowedSchemes,
+    });
+
+    // Try HEAD first; some servers don't support it. If it fails, do a minimal GET.
+    const head = await this.tryRequest(parsed, { method: "HEAD" });
+    if (head.ok) {
+      return extractMetadataOrThrow(url, head, this.config.maxSizeBytes);
+    }
+
+    // Range GET: avoid large downloads; still gets headers.
+    const get = await this.tryRequest(parsed, {
+      method: "GET",
+      headers: { Range: "bytes=0-0" },
+    });
+
+    if (!get.ok) {
+      throw new UpstreamError(
+        `HTTP ${get.status}: ${get.statusText}`,
+        mapStatus(get.status),
+      );
+    }
+
+    return extractMetadataOrThrow(url, get, this.config.maxSizeBytes);
+  }
+
+  private async tryRequest(url: URL, init: RequestInit): Promise<Response> {
+    const { controller, timeoutId } = createTimeoutAbortController(
+      this.config.timeoutMs,
+    );
+
+    try {
+      const response = await this.fetchImpl(url, {
+        ...init,
+        redirect: this.config.followRedirects ? "follow" : "manual",
+        signal: controller.signal,
+        headers: {
+          "User-Agent": this.config.userAgent,
+          ...normalizeHeaders(init.headers),
+        },
+      });
+
+      // Treat redirects as an error when redirects are disabled.
+      if (
+        !this.config.followRedirects &&
+        response.status >= 300 &&
+        response.status < 400
+      ) {
+        throw new UpstreamError("Redirects are not allowed", 400);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof UpstreamError) {
+        throw error;
+      }
+      if (isAbortError(error)) {
+        throw new UpstreamError("Upstream request timed out", 504, error);
+      }
+      throw new UpstreamError("Upstream request failed", 502, error);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function extractMetadataOrThrow(
+  originalUrl: string,
+  response: Response,
+  maxSizeBytes: number,
+): ImageProbeResult {
+  const size = getContentSizeBytes(response);
+  if (typeof size === "number" && size > maxSizeBytes) {
+    throw new TooLargeError(
+      `Image too large: ${size} bytes (max: ${maxSizeBytes})`,
+    );
+  }
+
+  const contentType = response.headers.get("content-type");
+  const mimeType = contentType ? normalizeMimeType(contentType) : null;
+  if (mimeType && !isImageMimeType(mimeType)) {
+    throw new NotImageError();
+  }
+
+  const extensionFromMime = mimeType ? extensionFromMimeType(mimeType) : null;
+  const extension =
+    extensionFromMime ?? inferImageExtensionFromUrl(originalUrl);
+
+  return {
+    size: size ?? null,
+    mimeType,
+    extension,
+  };
+}
+
+function getContentSizeBytes(response: Response): number | null {
+  const contentRange = response.headers.get("content-range");
+  if (contentRange) {
+    // Example: "bytes 0-0/12345"
+    const slashIndex = contentRange.lastIndexOf("/");
+    if (slashIndex !== -1) {
+      const totalRaw = contentRange.slice(slashIndex + 1).trim();
+      if (totalRaw !== "*") {
+        const total = Number(totalRaw);
+        if (!Number.isNaN(total)) return total;
+      }
+    }
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (!contentLength) return null;
+
+  const size = Number(contentLength);
+  return Number.isNaN(size) ? null : size;
+}
+
+function inferImageExtensionFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname;
+    const lastDotIndex = pathname.lastIndexOf(".");
+    if (lastDotIndex === -1) return null;
+
+    const ext = pathname.slice(lastDotIndex + 1).toLowerCase();
+    return isValidImageExtension(ext) ? ext : null;
+  } catch {
+    return null;
+  }
+}
+
+function mapStatus(upstreamStatus: number): number {
+  // Avoid leaking upstream 5xx directly; treat as bad gateway.
+  if (upstreamStatus >= 500) return 502;
+  return upstreamStatus;
+}
+
+function createTimeoutAbortController(timeoutMs: number): {
+  controller: AbortController;
+  timeoutId: ReturnType<typeof setTimeout>;
+} {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  return { controller, timeoutId };
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function normalizeHeaders(
+  headers: HeadersInit | undefined,
+): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return headers;
+}

--- a/web/src/types/imageMetadata.ts
+++ b/web/src/types/imageMetadata.ts
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Image dimensions in pixels.
+ */
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Normalized image metadata for UI display.
+ */
+export interface ImageMetadata {
+  sizeKiB: number | null;
+  dimensions: ImageDimensions | null;
+  extension: string | null;
+  mimeType: string | null;
+}
+
+/**
+ * Raw metadata returned by a probe endpoint.
+ */
+export interface RawImageMetadata {
+  size?: number;
+  extension?: string;
+  mimeType?: string;
+}
+
+/**
+ * Dependency for fetching image metadata from an external source.
+ */
+export interface ImageMetadataFetcher {
+  /**
+   * Fetch metadata for an image URL.
+   *
+   * Parameters
+   * ----------
+   * url : string
+   *     Image URL to probe.
+   * options : object, optional
+   *     Optional abort signal for request cancellation.
+   */
+  fetchMetadata(
+    url: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<RawImageMetadata>;
+}
+
+/**
+ * Dependency for loading image dimensions (width/height).
+ */
+export interface ImageDimensionLoader {
+  /**
+   * Load image natural dimensions.
+   *
+   * Parameters
+   * ----------
+   * url : string
+   *     Image URL to load.
+   * options : object, optional
+   *     Optional abort signal for cancellation.
+   */
+  loadDimensions(
+    url: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ImageDimensions | null>;
+}

--- a/web/src/types/imageProbe.ts
+++ b/web/src/types/imageProbe.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Result returned by the probe-image API route.
+ */
+export interface ImageProbeResult {
+  size: number | null;
+  mimeType: string | null;
+  extension: string | null;
+}
+
+/**
+ * Configuration for probing remote images.
+ */
+export interface ImageProbeConfig {
+  maxSizeBytes: number;
+  timeoutMs: number;
+  allowedSchemes: ReadonlySet<"http" | "https">;
+  userAgent: string;
+  followRedirects: boolean;
+}
+
+/**
+ * Base error type for image probe failures with an HTTP status code.
+ */
+export class ImageProbeError extends Error {
+  public readonly statusCode: number;
+
+  /**
+   * Parameters
+   * ----------
+   * message : string
+   *     Error message safe to return to clients.
+   * statusCode : number
+   *     HTTP status code to return.
+   * cause : unknown, optional
+   *     Underlying error, if any.
+   */
+  constructor(message: string, statusCode: number, cause?: unknown) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "ImageProbeError";
+    this.statusCode = statusCode;
+  }
+}
+
+export class InvalidUrlError extends ImageProbeError {
+  constructor(message = "Invalid URL", cause?: unknown) {
+    super(message, 400, cause);
+    this.name = "InvalidUrlError";
+  }
+}
+
+export class SSRFError extends ImageProbeError {
+  constructor(message = "Forbidden URL") {
+    super(message, 400);
+    this.name = "SSRFError";
+  }
+}
+
+export class UpstreamError extends ImageProbeError {
+  constructor(message: string, statusCode: number, cause?: unknown) {
+    super(message, statusCode, cause);
+    this.name = "UpstreamError";
+  }
+}
+
+export class NotImageError extends ImageProbeError {
+  constructor(message = "URL does not point to an image") {
+    super(message, 400);
+    this.name = "NotImageError";
+  }
+}
+
+export class TooLargeError extends ImageProbeError {
+  constructor(message = "Image too large") {
+    super(message, 413);
+    this.name = "TooLargeError";
+  }
+}

--- a/web/src/utils/imageMetadata.ts
+++ b/web/src/utils/imageMetadata.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  ImageDimensions,
+  ImageMetadata,
+  RawImageMetadata,
+} from "@/types/imageMetadata";
+
+/**
+ * Empty image metadata value.
+ */
+export const EMPTY_IMAGE_METADATA: ImageMetadata = Object.freeze({
+  sizeKiB: null,
+  dimensions: null,
+  extension: null,
+  mimeType: null,
+});
+
+/**
+ * Convert bytes to kibibytes (KiB), rounded to 1 decimal place.
+ *
+ * Parameters
+ * ----------
+ * bytes : number
+ *     Size in bytes.
+ */
+export function bytesToKiB(bytes: number): number {
+  return Math.round((bytes / 1024) * 10) / 10;
+}
+
+/**
+ * Format an extension for display.
+ *
+ * Parameters
+ * ----------
+ * extension : string or null or undefined
+ *     File extension (e.g. "jpg").
+ */
+export function formatExtension(
+  extension: string | null | undefined,
+): string | null {
+  return extension ? extension.toUpperCase() : null;
+}
+
+/**
+ * Combine raw probe metadata and dimensions into the normalized UI model.
+ *
+ * Parameters
+ * ----------
+ * raw : RawImageMetadata or null or undefined
+ *     Raw metadata returned by a probe implementation.
+ * dimensions : ImageDimensions or null
+ *     Natural dimensions if available.
+ */
+export function combineImageMetadata(
+  raw: RawImageMetadata | null | undefined,
+  dimensions: ImageDimensions | null,
+): ImageMetadata {
+  const size = raw?.size;
+  const extension = raw?.extension;
+  const mimeType = raw?.mimeType;
+
+  return {
+    sizeKiB: typeof size === "number" ? bytesToKiB(size) : null,
+    dimensions,
+    extension: formatExtension(extension),
+    mimeType: mimeType ?? null,
+  };
+}

--- a/web/src/utils/metadata/mimeTypes.test.ts
+++ b/web/src/utils/metadata/mimeTypes.test.ts
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { describe, expect, it } from "vitest";
+import {
+  extensionFromMimeType,
+  isImageMimeType,
+  isValidImageExtension,
+  normalizeMimeType,
+} from "./mimeTypes";
+
+describe("mimeTypes utils", () => {
+  describe("normalizeMimeType", () => {
+    it.each([
+      { input: "image/jpeg", expected: "image/jpeg" },
+      { input: "image/jpeg; charset=utf-8", expected: "image/jpeg" },
+      { input: " Image/PNG ; q=0.9", expected: "image/png" },
+      { input: "text/html; charset=utf-8", expected: "text/html" },
+    ])("should normalize '$input' -> '$expected'", ({ input, expected }) => {
+      expect(normalizeMimeType(input)).toBe(expected);
+    });
+  });
+
+  describe("extensionFromMimeType", () => {
+    it.each([
+      { mimeType: "image/jpeg", expected: "jpg" },
+      { mimeType: "image/jpg", expected: "jpg" },
+      { mimeType: "image/png", expected: "png" },
+      { mimeType: "image/avif", expected: "avif" },
+      { mimeType: "image/unknown", expected: null },
+    ])("should return $expected for mime '$mimeType'", ({
+      mimeType,
+      expected,
+    }) => {
+      expect(extensionFromMimeType(mimeType)).toBe(expected);
+    });
+  });
+
+  describe("isImageMimeType", () => {
+    it.each([
+      { mimeType: "image/jpeg", expected: true },
+      { mimeType: "image/svg+xml", expected: true },
+      { mimeType: "text/html", expected: false },
+      { mimeType: "application/json", expected: false },
+    ])("should return $expected for mime '$mimeType'", ({
+      mimeType,
+      expected,
+    }) => {
+      expect(isImageMimeType(mimeType)).toBe(expected);
+    });
+  });
+
+  describe("isValidImageExtension", () => {
+    it.each([
+      { ext: "jpg", expected: true },
+      { ext: "JPG", expected: true },
+      { ext: "jpeg", expected: true },
+      { ext: "png", expected: true },
+      { ext: "svg", expected: true },
+      { ext: "webp", expected: true },
+      { ext: "exe", expected: false },
+      { ext: "html", expected: false },
+      { ext: "", expected: false },
+    ])("should return $expected for ext '$ext'", ({ ext, expected }) => {
+      expect(isValidImageExtension(ext)).toBe(expected);
+    });
+  });
+});

--- a/web/src/utils/metadata/mimeTypes.ts
+++ b/web/src/utils/metadata/mimeTypes.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Normalize a Content-Type header value to its mime type.
+ *
+ * Parameters
+ * ----------
+ * contentType : string
+ *     Content-Type header value.
+ */
+export function normalizeMimeType(contentType: string): string {
+  const [mimeRaw] = contentType.split(";");
+  return (mimeRaw ?? "").trim().toLowerCase();
+}
+
+const MIME_TO_EXTENSION = new Map<string, string>([
+  ["image/jpeg", "jpg"],
+  ["image/jpg", "jpg"],
+  ["image/png", "png"],
+  ["image/gif", "gif"],
+  ["image/webp", "webp"],
+  ["image/bmp", "bmp"],
+  ["image/tiff", "tiff"],
+  ["image/svg+xml", "svg"],
+  ["image/avif", "avif"],
+  ["image/heic", "heic"],
+]);
+
+const VALID_IMAGE_EXTENSIONS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "bmp",
+  "tiff",
+  "svg",
+  "avif",
+  "heic",
+]);
+
+/**
+ * Map an image mime type to a common file extension.
+ *
+ * Parameters
+ * ----------
+ * mimeType : string
+ *     Mime type (e.g. "image/jpeg").
+ */
+export function extensionFromMimeType(mimeType: string): string | null {
+  return MIME_TO_EXTENSION.get(mimeType) ?? null;
+}
+
+/**
+ * Whether a mime type is an image mime type.
+ *
+ * Parameters
+ * ----------
+ * mimeType : string
+ *     Mime type.
+ */
+export function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+/**
+ * Validate that an extension is a known image extension.
+ *
+ * Parameters
+ * ----------
+ * extension : string
+ *     File extension without dot.
+ */
+export function isValidImageExtension(extension: string): boolean {
+  return VALID_IMAGE_EXTENSIONS.has(extension.toLowerCase());
+}

--- a/web/src/utils/security/ssrf.test.ts
+++ b/web/src/utils/security/ssrf.test.ts
@@ -1,0 +1,120 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InvalidUrlError, SSRFError } from "@/types/imageProbe";
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(),
+}));
+
+import { lookup } from "node:dns/promises";
+import { validateRemoteHttpUrl } from "./ssrf";
+
+const ALLOWED_SCHEMES = new Set<"http" | "https">(["http", "https"]);
+
+type DnsLookupAll = (
+  hostname: string,
+  options: { all: true; verbatim: true },
+) => Promise<Array<{ address: string; family: number }>>;
+
+function mockLookupAll(resolved: Array<{ address: string; family: number }>) {
+  (
+    lookup as unknown as ReturnType<typeof vi.fn<DnsLookupAll>>
+  ).mockResolvedValue(resolved);
+}
+
+/**
+ * Validate a URL using the standard allowlist.
+ *
+ * Parameters
+ * ----------
+ * url : string
+ *     URL to validate.
+ */
+async function validate(url: string) {
+  return await validateRemoteHttpUrl(url, { allowedSchemes: ALLOWED_SCHEMES });
+}
+
+describe("ssrf utils", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validateRemoteHttpUrl", () => {
+    it.each([
+      { url: "not-a-url", error: InvalidUrlError },
+      { url: "file:///etc/passwd", error: InvalidUrlError },
+      { url: "ftp://example.com/image.jpg", error: InvalidUrlError },
+    ])("should reject invalid URL '$url'", async ({ url, error }) => {
+      await expect(validate(url)).rejects.toBeInstanceOf(error);
+    });
+
+    it.each([
+      { url: "http://localhost/image.jpg" },
+      { url: "http://metadata.google.internal/latest/meta-data" },
+      { url: "http://metadata/" },
+    ])("should reject blocked hostname '$url'", async ({ url }) => {
+      await expect(validate(url)).rejects.toBeInstanceOf(SSRFError);
+    });
+
+    it.each([
+      { url: "http://127.0.0.1/image.jpg" },
+      { url: "http://127.0.0.2/image.jpg" },
+      { url: "http://10.0.0.1/image.jpg" },
+      { url: "http://172.16.0.1/image.jpg" },
+      { url: "http://192.168.1.1/image.jpg" },
+      { url: "http://169.254.169.254/latest/meta-data/" },
+      { url: "http://0.0.0.0/image.jpg" },
+      { url: "http://224.0.0.1/image.jpg" },
+      // IPv6 literals must be bracketed in URLs.
+      { url: "http://[::1]/image.jpg" },
+      { url: "http://[fc00::1]/image.jpg" },
+      { url: "http://[fe80::1]/image.jpg" },
+      { url: "http://[::]/image.jpg" },
+    ])("should reject private/local IP literal '$url'", async ({ url }) => {
+      await expect(validate(url)).rejects.toBeInstanceOf(SSRFError);
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it("should allow public IP literals without DNS lookup", async () => {
+      const result = await validate("https://8.8.8.8/image.jpg");
+      expect(result.hostname).toBe("8.8.8.8");
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it("should reject hostnames resolving to private IPs", async () => {
+      // `lookup` has overloads; in our code we always call it with `{ all: true }`,
+      // which resolves to an array of records.
+      mockLookupAll([{ address: "192.168.1.10", family: 4 }]);
+
+      await expect(
+        validate("https://example.com/image.jpg"),
+      ).rejects.toBeInstanceOf(SSRFError);
+
+      expect(lookup).toHaveBeenCalledWith("example.com", {
+        all: true,
+        verbatim: true,
+      });
+    });
+
+    it("should allow hostnames resolving to public IPs", async () => {
+      mockLookupAll([{ address: "93.184.216.34", family: 4 }]);
+
+      const result = await validate("https://example.com/image.jpg");
+      expect(result.hostname).toBe("example.com");
+    });
+  });
+});

--- a/web/src/utils/security/ssrf.ts
+++ b/web/src/utils/security/ssrf.ts
@@ -1,0 +1,177 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+import { InvalidUrlError, SSRFError } from "@/types/imageProbe";
+
+export interface ValidateRemoteUrlOptions {
+  allowedSchemes: ReadonlySet<"http" | "https">;
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata",
+  "metadata.google.internal",
+  "metadata.google",
+]);
+
+/**
+ * Validate that a URL is an external http(s) URL and reject common SSRF targets.
+ *
+ * This performs:
+ * - Scheme allowlisting
+ * - Blocklist of well-known internal hostnames
+ * - Blocking for IP literals in private / loopback / link-local ranges
+ * - DNS resolution and blocking if any resolved IP is private
+ *
+ * Parameters
+ * ----------
+ * rawUrl : string
+ *     Input URL to validate.
+ * options : ValidateRemoteUrlOptions
+ *     Validation options.
+ *
+ * Returns
+ * -------
+ * URL
+ *     Parsed URL if allowed.
+ */
+export async function validateRemoteHttpUrl(
+  rawUrl: string,
+  options: ValidateRemoteUrlOptions,
+): Promise<URL> {
+  const parsed = parseUrl(rawUrl);
+  validateScheme(parsed, options.allowedSchemes);
+
+  const hostname = normalizeHostname(parsed.hostname.toLowerCase());
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new SSRFError(`Access to ${hostname} is forbidden`);
+  }
+
+  const ipKind = isIP(hostname);
+  if (ipKind !== 0) {
+    if (isPrivateIpLiteral(hostname)) {
+      throw new SSRFError("Access to private or local IP ranges is forbidden");
+    }
+    return parsed;
+  }
+
+  // DNS resolution: reject if hostname resolves to any private/local IP.
+  // NOTE: This mitigates (but does not fully eliminate) DNS rebinding risks.
+  const records = await lookup(hostname, { all: true, verbatim: true });
+  for (const r of records) {
+    if (isPrivateIpLiteral(r.address)) {
+      throw new SSRFError("Hostname resolves to a private or local IP");
+    }
+  }
+
+  return parsed;
+}
+
+function parseUrl(rawUrl: string): URL {
+  try {
+    return new URL(rawUrl);
+  } catch (error) {
+    throw new InvalidUrlError("Malformed URL", error);
+  }
+}
+
+function validateScheme(
+  url: URL,
+  allowedSchemes: ReadonlySet<"http" | "https">,
+): void {
+  const proto = url.protocol.toLowerCase();
+  if (proto !== "http:" && proto !== "https:") {
+    throw new InvalidUrlError(`Protocol ${url.protocol} not allowed`);
+  }
+
+  const scheme = proto.slice(0, -1) as "http" | "https";
+  if (!allowedSchemes.has(scheme)) {
+    throw new InvalidUrlError(`Scheme ${scheme} not allowed`);
+  }
+}
+
+function isPrivateIpLiteral(ip: string): boolean {
+  // IPv6
+  if (ip.includes(":")) {
+    const normalized = ip.toLowerCase();
+
+    if (normalized === "::" || normalized === "::1") return true; // unspecified/loopback
+    if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true; // fc00::/7 unique local
+    if (
+      normalized.startsWith("fe8") ||
+      normalized.startsWith("fe9") ||
+      normalized.startsWith("fea") ||
+      normalized.startsWith("feb")
+    ) {
+      return true; // fe80::/10 link-local
+    }
+
+    // IPv4-mapped IPv6: ::ffff:127.0.0.1
+    const v4MappedPrefix = "::ffff:";
+    if (normalized.startsWith(v4MappedPrefix)) {
+      const v4 = normalized.slice(v4MappedPrefix.length);
+      return isPrivateIpv4(v4);
+    }
+
+    return false;
+  }
+
+  // IPv4
+  return isPrivateIpv4(ip);
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return true;
+
+  const nums = parts.map((p) => Number(p));
+  if (nums.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+
+  const a = nums[0];
+  const b = nums[1];
+  if (a === undefined || b === undefined) return true;
+
+  // 0.0.0.0/8
+  if (a === 0) return true;
+  // 127.0.0.0/8
+  if (a === 127) return true;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 169.254.0.0/16 (incl. 169.254.169.254 metadata)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 (carrier-grade NAT)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 198.18.0.0/15 (benchmarking)
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // Multicast 224.0.0.0/4 and reserved 240.0.0.0/4
+  if (a >= 224) return true;
+
+  return false;
+}
+
+function normalizeHostname(hostname: string): string {
+  // Node's WHATWG URL keeps brackets for IPv6 literals in `hostname` (e.g. "[::1]").
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds image metadata probing functionality to display cover image technical details (file size, dimensions, extension) in the metadata fetch screen.

# Problem

Users viewing metadata search results cannot see technical details about cover images (file size, dimensions, file type) without manually inspecting the image or making separate requests.

# Solution

Implemented a comprehensive image metadata probing system:

1. **Backend API endpoint** (): Server-side endpoint that probes external image URLs for size (Content-Length), MIME type, and inferred extension. Includes SSRF protection and proper error handling.

2. **Image metadata services**: 
   - : Server-side service for probing images with SSRF validation, timeout, and size limits
   - : Client-side service that combines metadata from proxy fetcher and browser dimension loader

3. **React hook** (): Custom hook that fetches image metadata in a best-effort manner with proper cleanup and abort signal support.

4. **UI integration**: Updated  to display cover image technical details (size in KiB, dimensions, extension) below the cover image.

The implementation follows security best practices with SSRF protection, proper error handling, and follows DRY/SRP/IOC principles with dependency injection for testability.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)