### PR TITLE
Fix fetch context binding in ProxyImageMetadataFetcher

### DIFF
--- a/web/src/services/imageMetadata.ts
+++ b/web/src/services/imageMetadata.ts
@@ -46,7 +46,9 @@ export class ProxyImageMetadataFetcher implements ImageMetadataFetcher {
    */
   constructor(params: { endpoint?: string; fetchImpl?: FetchLike } = {}) {
     this.endpoint = params.endpoint ?? "/api/metadata/probe-image";
-    this.fetchImpl = params.fetchImpl ?? fetch;
+    // Bind fetch to the global scope to avoid "Illegal invocation" errors
+    // when called as a method of this class.
+    this.fetchImpl = params.fetchImpl ?? ((input, init) => fetch(input, init));
   }
 
   async fetchMetadata(


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes a TypeError that prevented image metadata probing from working in production by properly binding the fetch function to the global scope.

# Problem

The  hook was not attempting to probe image covers in production deployments, even though the  route exists and works correctly (verified via curl). The browser console showed the error:

```
TypeError: 'fetch' called on an object that does not implement interface Window
```

This occurred because the native `fetch` function was being assigned directly to a class property (`this.fetchImpl`), which caused it to lose its binding to the global `window` object when called as a method. As a result, the metadata fetch silently failed (caught by `Promise.allSettled`), and only image dimensions were displayed (loaded via a separate `Image` object), while file size and MIME type were missing.

# Solution

Wrapped the default `fetch` implementation in an arrow function within the `ProxyImageMetadataFetcher` constructor to preserve the global context:

```typescript
this.fetchImpl = params.fetchImpl ?? ((input, init) => fetch(input, init));
```

This ensures that `fetch` is always called with the correct global scope, regardless of how it's invoked as a class method.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)