### PR TITLE
Fix: Robust file discovery for book merging with case-insensitive search

### DIFF
--- a/bookcard/services/book_merge/mergers.py
+++ b/bookcard/services/book_merge/mergers.py
@@ -162,7 +162,7 @@ class FileMerger:
                     data, keep_formats[fmt], src_file, keep_dir, keep_book, merge_book
                 )
             else:
-                self._move_and_link(data, src_file, keep_dir, keep_book)
+                self._move_and_link(data, src_file, keep_book)
 
     def _handle_conflict(
         self,
@@ -200,11 +200,17 @@ class FileMerger:
             self._file_storage.backup_file(keep_file)
 
             # Move src to keep location
-            self._file_storage.move_file(src_file, keep_file)
+            # Use add_format to ensure consistency, treating it as a new format essentially but replacing
+            if not keep_book.id:
+                logger.error("Cannot add format to book without ID")
+                return
 
-            # Update DB record for keep_book
-            keep_data_record.uncompressed_size = src_size
-            self._repository.save(keep_data_record)
+            self._repository.add_format(
+                book_id=keep_book.id,
+                file_path=src_file,
+                file_format=keep_data_record.format,
+                replace=True,
+            )
 
         else:
             # Keep is better (or equal), just move src as backup
@@ -217,27 +223,26 @@ class FileMerger:
             dest_bak = self._file_storage.get_unique_bak_path(keep_file)
             self._file_storage.move_file(src_file, dest_bak)
 
-    def _move_and_link(
-        self, data: Data, src_file: Path, keep_dir: Path, keep_book: Book
-    ) -> None:
-        """Move file and update data record."""
-        dest_file = keep_dir / self._construct_filename(data.name, data.format)
+    def _move_and_link(self, data: Data, src_file: Path, keep_book: Book) -> None:
+        """Move file and update data record using standard add_format mechanism."""
+        # This uses the repository's add_format which mimics standard Calibre behavior:
+        # 1. Renames file to match book convention
+        # 2. Updates/Creates Data record
+        # 3. Updates Book last_modified
 
-        # Handle filename collision if file exists but not in DB
-        if self._file_storage.exists(dest_file):
-            stem = dest_file.stem
-            suffix = dest_file.suffix
-            counter = 1
-            while self._file_storage.exists(dest_file):
-                dest_file = keep_dir / f"{stem}_{counter}{suffix}"
-                counter += 1
+        # Note: We don't need to manually update data.book = keep_book.id because
+        # add_format will create a NEW Data record for the keep_book.
+        # The OLD Data record (for merge_book) will be deleted during cleanup.
+        if not keep_book.id:
+            logger.error("Cannot add format to book without ID")
+            return
 
-        self._file_storage.move_file(src_file, dest_file)
-
-        # Update Data record to point to keep_book
-        data.book = keep_book.id
-        data.name = dest_file.stem
-        self._repository.save(data)
+        self._repository.add_format(
+            book_id=keep_book.id,
+            file_path=src_file,
+            file_format=data.format,
+            replace=False,
+        )
 
     def _construct_filename(self, name: str, fmt: str) -> str:
         """Construct filename with lowercase extension."""

--- a/bookcard/services/book_merge/protocols.py
+++ b/bookcard/services/book_merge/protocols.py
@@ -41,6 +41,17 @@ class BookRepository(Protocol):
         """Get book with associated data records."""
         ...
 
+    def add_format(
+        self,
+        *,
+        book_id: int,
+        file_path: Path,
+        file_format: str,
+        replace: bool = False,
+    ) -> None:
+        """Add format to book using standard mechanism."""
+        ...
+
     def save(self, instance: object) -> None:
         """Save instance to database."""
         ...

--- a/bookcard/services/book_merge_service.py
+++ b/bookcard/services/book_merge_service.py
@@ -19,6 +19,7 @@ Follows SRP by focusing solely on book merge orchestration.
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from sqlmodel import Session
@@ -63,7 +64,7 @@ class BookMergeService:
         self._library_path = library_path
 
         # Initialize infrastructure
-        self._repository = SQLBookRepository(session)
+        self._repository = SQLBookRepository(session, Path(library_path))
         self._file_storage = LocalFileStorage(library_path)
 
         # Initialize domain services


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Enhances book merging functionality by adding case-insensitive file discovery and standardizing format management through a centralized add_format mechanism.

# Problem

The book merging process was failing when files couldn't be found due to case-sensitivity mismatches between the database records and actual filesystem paths. Additionally, file operations during merging were inconsistent, using ad-hoc logic instead of standardized format management.

# Solution

1. **Added case-insensitive file discovery**: Implemented  method in  that performs case-insensitive matching of file stems and extensions, making file discovery more robust.

2. **Standardized format management**: Added  method to  that handles adding formats to books using standard Calibre-like logic, ensuring consistent file naming, database updates, and last_modified timestamp management.

3. **Updated FileMerger**: Modified  to use the new  method for robust file discovery and  for consistent format management, replacing ad-hoc file operations.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)