### PR TITLE
Fix Storybook security vulnerability (8.5.8 → 8.6.15)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,10 +42,10 @@
         "@lingual/i18n-check": "^0.8.12",
         "@playwright/test": "^1.56.1",
         "@spotlightjs/spotlight": "^4.10.0",
-        "@storybook/addon-a11y": "^10.1.10",
-        "@storybook/addon-docs": "^10.1.10",
-        "@storybook/addon-vitest": "^10.1.10",
-        "@storybook/nextjs-vite": "^10.1.10",
+        "@storybook/addon-a11y": "^10.1.11",
+        "@storybook/addon-docs": "^10.1.11",
+        "@storybook/addon-vitest": "^10.1.11",
+        "@storybook/nextjs-vite": "^10.1.11",
         "@tailwindcss/postcss": "^4.1.16",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -72,7 +72,7 @@
         "rimraf": "^6.1.2",
         "sass": "^1.93.3",
         "semantic-release": "^25.0.1",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "tailwindcss": "^4.1.16",
         "typescript": "^5.9.3",
         "vite-tsconfig-paths": "^5.1.4",
@@ -570,9 +570,9 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-actions": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.5.8.tgz",
-      "integrity": "sha512-7J0NAz+WDw1NmvmKIh0Qr5cxgVRDPFC5fmngbDNxedk147TkwrgmqOypgEi/SAksHbTWxJclbimoqdcsNtWffA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.15.tgz",
+      "integrity": "sha512-zc600PBJqP9hCyRY5escKgKf6Zt9kdNZfm+Jwb46k5/NMSO4tNVeOPGBFxW9kSsIYk8j55sNske+Yh60G+8bcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -587,13 +587,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-backgrounds": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.5.8.tgz",
-      "integrity": "sha512-TsQFagQ95+d7H3/+qUZKI2B0SEK8iu6CV13cyry9Dm59nn2bBylFrwx4I3xDQUOWMiSF6QIRjCYzxKQ/jJ5OEg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.15.tgz",
+      "integrity": "sha512-W36uEzMWPO/K3+8vV1R/GozdaFrIix0qqmxX0qoAT6/o4+zqHiloZkTF+2iuUTx/VmuztLcAoSaPDh8UPy3Q+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,13 +606,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-controls": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.5.8.tgz",
-      "integrity": "sha512-3iifI8mBGPsiPmV9eAYk+tK9i+xuWhVsa+sXz01xTZ/0yoOREpp972hka86mtCqdDTOJIpzh1LmxvB218OssvQ==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.15.tgz",
+      "integrity": "sha512-CgV8WqGxQrqSKs1a/Y1v4mrsBJXGFmO5u4kvdhPbftRVfln11W4Hvc1SFmgXwGvmcwekAKH79Uwwkjhj3l6gzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -625,20 +625,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-docs": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.5.8.tgz",
-      "integrity": "sha512-zKVUqE0UGiq1gZtY2TX57SYB4RIsdlbTDxKW2JZ9HhZGLvZ5Qb7AvdiKTZxfOepGhuw3UcNXH/zCFkFCTJifMw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.15.tgz",
+      "integrity": "sha512-Nm5LlxwAmGQRkCUY36FhtCLz21C+5XlydF7/bkBOHsf08p2xR5MNLMSPrIhte/PY7ne9viNUCm1d3d3LiWnkKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.5.8",
-        "@storybook/csf-plugin": "8.5.8",
-        "@storybook/react-dom-shim": "8.5.8",
+        "@storybook/blocks": "8.6.15",
+        "@storybook/csf-plugin": "8.6.15",
+        "@storybook/react-dom-shim": "8.6.15",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -648,25 +648,25 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-essentials": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.5.8.tgz",
-      "integrity": "sha512-sCNvMZqL6dywnyHuZBrWl4f6QXsvpJHOioL3wJJKaaRMZmctbFmS0u6J8TQjmgZhQfyRzuJuhr1gJg9oeqp6AA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.15.tgz",
+      "integrity": "sha512-BIcE/7t5WXDXs4+zycm7MLNPHA2219ImkKO70IH7uxGM4cm7jDuJ5v0crkAvNeeRVsZixT2P2L9EfUfi1cFCQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/addon-actions": "8.5.8",
-        "@storybook/addon-backgrounds": "8.5.8",
-        "@storybook/addon-controls": "8.5.8",
-        "@storybook/addon-docs": "8.5.8",
-        "@storybook/addon-highlight": "8.5.8",
-        "@storybook/addon-measure": "8.5.8",
-        "@storybook/addon-outline": "8.5.8",
-        "@storybook/addon-toolbars": "8.5.8",
-        "@storybook/addon-viewport": "8.5.8",
+        "@storybook/addon-actions": "8.6.15",
+        "@storybook/addon-backgrounds": "8.6.15",
+        "@storybook/addon-controls": "8.6.15",
+        "@storybook/addon-docs": "8.6.15",
+        "@storybook/addon-highlight": "8.6.15",
+        "@storybook/addon-measure": "8.6.15",
+        "@storybook/addon-outline": "8.6.15",
+        "@storybook/addon-toolbars": "8.6.15",
+        "@storybook/addon-viewport": "8.6.15",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -674,13 +674,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-highlight": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.5.8.tgz",
-      "integrity": "sha512-kkldtFrY0oQJY/vfNLkV66hVgtp66OO8T68KoZFsmUz4a3iYgzDS8WF+Av2/9jthktFvMchjFr8NKOno9YBGIg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.15.tgz",
+      "integrity": "sha512-lOu44QTVw5nR8kzag0ukxWnLq48oy2MqMUDuMVFQWPBKX8ayhmgl2OiEcvAOVNsieTHrr2W4CkP7FFvF4D0vlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -691,13 +691,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-measure": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.5.8.tgz",
-      "integrity": "sha512-xf84ByTRkFPoNSck6Z5OJ0kXTYAYgmg/0Ke0eCY/CNgwh7lfjYQBrcjuKiYZ6jyRUMLdysXzIfF9/2MeFqLfIg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.15.tgz",
+      "integrity": "sha512-F78fJlmuXMulTphFp9Iqx7I1GsbmNLboChnW/VqR6nRZx5o9cdGjc8IaEyXVFXZ7k1pnSvdaP5ndFmzkcPxQdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -709,13 +709,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-outline": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.5.8.tgz",
-      "integrity": "sha512-NAC9VWZFg2gwvduzJRVAtxPeQfJjB8xfDDgcGjgLOCSQkZDDOmGVdLXf78pykMQKyuu/0YZ989KufAac6kRG5g==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.15.tgz",
+      "integrity": "sha512-rpGRLajsjBdpbggPmdNZbftF68zQwsYLosu7YiUSBaR4dm+gQ+7m5nLLI/MjZDHbt2nJRW94yXpn7dUw2CDF6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -727,13 +727,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-toolbars": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.5.8.tgz",
-      "integrity": "sha512-AfGdMNBp+vOjyiFKlOyUFLIU0kN1QF4PhVBqd0vYkWAk2w9n6a/ZlG0TcJGe7K5+bcvmZDAerYMKbDMSeg9bAw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.15.tgz",
+      "integrity": "sha512-NfHAbOOu5qI9SQq6jJr2VfinaZpHrmz3bavBeUppxCxM+zfPuNudK8MlMOOuyPBPAoUqcDSoKZgNfCkOBQcyGg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -741,13 +741,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/addon-viewport": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.5.8.tgz",
-      "integrity": "sha512-SdoRb4bH99Knj2R+rTcMQQxHrtcIO1GLzTFitAefxBE1OUkq8FNLHMHd0Ip/sCQGLW/5F03U70R2uh7SkhBBYA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.15.tgz",
+      "integrity": "sha512-ylTK4sehAeVTwcYMZyisyP3xX+m43NjJrQHKc3DAII3Z3RFqTv9l6CUMogM2/8mysTzoo8xYVtQB6hX7zB8Dew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -758,17 +758,16 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/blocks": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.5.8.tgz",
-      "integrity": "sha512-O6tJDJM83fDm3ZP1+lTf24l7HOTzSRXkkMDD7zB/JHixzlj9p6wI4UQc2lplLadDCa5ya1IwyE7zUDN/0UfC5Q==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.15.tgz",
+      "integrity": "sha512-nc5jQkvPo0EirteHsrmcx9on/0lGQ8F4lUNky7kN2I5WM8Frr3cPTeRoAvzjUkOwrqt/vm3g+T4zSbmDq/OEDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf": "0.1.12",
         "@storybook/icons": "^1.2.12",
         "ts-dedent": "^2.0.0"
       },
@@ -779,7 +778,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -791,13 +790,13 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/builder-webpack5": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.5.8.tgz",
-      "integrity": "sha512-QaBIMyqWX/eQs4laQBXvAW9M/ylk73WljJySPlTl+8PNVuDtHli24oBJXwx5aV1NT53BLsaKAn/vb2QNL4+G1Q==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.6.15.tgz",
+      "integrity": "sha512-4UZAm0t8CxVMUjkTzLaBoCKG3Bqg+lEKxrPrTGRddLlVCB8olv23C3/MW1aQJfzde9ze6ofllkn97r1tVG6ipQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "8.5.8",
+        "@storybook/core-webpack": "8.6.15",
         "@types/semver": "^7.3.4",
         "browser-assert": "^1.2.1",
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
@@ -827,7 +826,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -836,9 +835,9 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/components": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.5.8.tgz",
-      "integrity": "sha512-PPEMqWPXn7rX+qISaOOv9CDSuuvG538f0+4M5Ppq2LwpjXecgOG5ktqJF0ZqxmTytT+RpEaJmgjGW0dMAKZswA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.15.tgz",
+      "integrity": "sha512-+9GVKXPEW8Kl9zvNSTm9+VrJtx/puMZiO7gxCML63nK4aTWJXHQr4t9YUoGammSBM3AV1JglsKm6dBgJEeCoiA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -850,9 +849,9 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/core-webpack": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.5.8.tgz",
-      "integrity": "sha512-M2LNQdYp0br8fgKMVtBh7YIo8mQsgALLc4i9PEXRS7wrp+bhvVnA9qhd5xDPzb0Rl4CHYbs4Yvkzo7ZQMibeIQ==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.6.15.tgz",
+      "integrity": "sha512-DZUxsF9KwzUGYzXg8gQ7xnAnLnulh8wkaxEqkVt7xMJ95FLZYCI8o+05tJ3tNUYzjPMTzoAUPL2OD9bb6HcSzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -863,7 +862,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/csf": {
@@ -877,9 +876,9 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/csf-plugin": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.5.8.tgz",
-      "integrity": "sha512-9p+TFutbvtPYEmg14UsvqBDWKP/p/+OkIdi+gkwCMw0yiJF/+7ErMHDB0vr5SpJpU7SFQmfpY2c/LaglEtaniw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.15.tgz",
+      "integrity": "sha512-ZLz/mtOoE1Jj2lE4pK3U7MmYrv5+lot3mGtwxGb832tcABMc97j9O+reCVxZYc7DeFbBuuEdMT9rBL/O3kXYmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -890,13 +889,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/manager-api": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.5.8.tgz",
-      "integrity": "sha512-ik3yikvYxAJMDFg0s3Pm7hZWucAlkFaaO7e2RlfOctaJFdaEi3evR4RS7GdmS38uKBEk31RC7x+nnIJkqEC59A==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.15.tgz",
+      "integrity": "sha512-ZOFtH821vFcwzECbFYFTKtSVO96Cvwwg45dMh3M/9bZIdN7klsloX7YNKw8OKvwE6XLFLsi2OvsNNcmTW6g88w==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -908,15 +907,15 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/preset-server-webpack": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-server-webpack/-/preset-server-webpack-8.5.8.tgz",
-      "integrity": "sha512-0QA23bmhchmec6zI0JzoXWIA723n8XhEtJndUQDS96cTyDGyb3AuedNgwu5xQw9Zv+EJZjO84uGcNYinPEnmKA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/preset-server-webpack/-/preset-server-webpack-8.6.15.tgz",
+      "integrity": "sha512-mYnx0nWW0/fOcHzda82+HYe5onYGR35ah9EMWk4f3BizoYEHWMJk/0DtVcj+qZ0JLdozc0PiY3dEQhW+tI78Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core-webpack": "8.5.8",
+        "@storybook/core-webpack": "8.6.15",
         "@storybook/global": "^5.0.0",
-        "@storybook/server": "8.5.8",
+        "@storybook/server": "8.6.15",
         "safe-identifier": "^0.4.1",
         "ts-dedent": "^2.0.0",
         "yaml-loader": "^0.8.0"
@@ -929,13 +928,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/preview-api": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.5.8.tgz",
-      "integrity": "sha512-HJoz2o28VVprnU5OG6JO6CHrD3ah6qVPWixbnmyUKd0hOYF5dayK5ptmeLyUpYX56Eb2KoYcuVaeQqAby4RkNw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.15.tgz",
+      "integrity": "sha512-oqsp8f7QekB9RzpDqOXZQcPPRXXd/mTsnZSdAAQB/pBVqUpC9h/y5hgovbYnJ6DWXcpODbMwH+wbJHZu5lvm+w==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -947,9 +946,9 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/react-dom-shim": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.5.8.tgz",
-      "integrity": "sha512-UT/kGJHPW+HLNCTmI1rV1to+dUZuXKUTaRv2wZ2BUq2/gjIuePyqQZYVQeb0LkZbuH2uviLrPfXpS5d3/RSUJw==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.15.tgz",
+      "integrity": "sha512-m2trBmmd4iom1qwrp1F109zjRDc0cPaHYhDQxZR4Qqdz8pYevYJTlipDbH/K4NVB6Rn687RT29OoOPfJh6vkFA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -959,22 +958,21 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/server": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/server/-/server-8.5.8.tgz",
-      "integrity": "sha512-DB3IR7CCUklTXtytbOOX7Vig1h9ohQ3BPauvf7WlYXLv4JlkO54oTu37rL0wbqgmmh4FOF41ZSX8z4h4w41How==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/server/-/server-8.6.15.tgz",
+      "integrity": "sha512-KYfSqsHOs+9D2e67+KFF1xlXsyhANr5Q6cNoXJiFEK9xWYmt2Lr1A9UNhxZwPUQls8EyHE2jV7pRpbkhXkq74A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/components": "8.5.8",
-        "@storybook/csf": "0.1.12",
+        "@storybook/components": "8.6.15",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "8.5.8",
-        "@storybook/preview-api": "8.5.8",
-        "@storybook/theming": "8.5.8",
+        "@storybook/manager-api": "8.6.15",
+        "@storybook/preview-api": "8.6.15",
+        "@storybook/theming": "8.6.15",
         "ts-dedent": "^2.0.0",
         "yaml": "^2.3.1"
       },
@@ -986,19 +984,19 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/server-webpack5": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/server-webpack5/-/server-webpack5-8.5.8.tgz",
-      "integrity": "sha512-bdRxp0kUGBstDdCEIfJEbsmM7vvyBES4Hjmj0jXcOefQYic5QTWTiDMrHgWPp8XWGjIoO+wOfWm2IXPP5Uceog==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/server-webpack5/-/server-webpack5-8.6.15.tgz",
+      "integrity": "sha512-C2s0scJHAhviscjDorbu9JYwGwbD9HvlNGUOyMSIpFDJtyjuHEsRwqkWHKwxWqUkLbe8qZjxpA8vOGzeH8Qbzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-webpack5": "8.5.8",
-        "@storybook/preset-server-webpack": "8.5.8",
-        "@storybook/server": "8.5.8"
+        "@storybook/builder-webpack5": "8.6.15",
+        "@storybook/preset-server-webpack": "8.6.15",
+        "@storybook/server": "8.6.15"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1008,13 +1006,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.5.8"
+        "storybook": "^8.6.15"
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/@storybook/theming": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.5.8.tgz",
-      "integrity": "sha512-/Rm6BV778sCT+3Ok861VYmw9BlEV5zcCq2zg5TOVuk8HqZw7H7VHtubVsjukEuhveYCs+oF+i2tv/II6jh6jdg==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
+      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1026,13 +1024,13 @@
       }
     },
     "node_modules/@chromatic-com/playwright/node_modules/storybook": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.5.8.tgz",
-      "integrity": "sha512-k3QDa7z4a656oO3Mx929KNm+xIdEI2nIDCKatVl1mA6vt+ge+uwoiG+ro182J9LOEppR5XXD2mQQi4u1xNsy6A==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.15.tgz",
+      "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core": "8.5.8"
+        "@storybook/core": "8.6.15"
       },
       "bin": {
         "getstorybook": "bin/index.cjs",
@@ -6875,9 +6873,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.1.10.tgz",
-      "integrity": "sha512-lXVFywCSdA39uCR0KEFz3F6WTjzoqSi5gQYtWrFelzaUiMH46uBLHPYaKlpUuNbTL/o9ctrhX1YNzegujrXSoQ==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.1.11.tgz",
+      "integrity": "sha512-3sr6HmcDgW1+TQAV9QtWBE3HlGyfFXVZY3RECTNLNH6fRC+rYQCItisvQIVxQpyftLSQ8EAMN9JQzs495MjWNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6889,20 +6887,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.1.10"
+        "storybook": "^10.1.11"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.1.10.tgz",
-      "integrity": "sha512-PSJVtawnGNrEkeLJQn9TTdeqrtDij8onvmnFtfkDaFG5IaUdQaLX9ibJ4gfxYakq+BEtlCcYiWErNJcqDrDluQ==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.1.11.tgz",
+      "integrity": "sha512-Jwm291Fhim2eVcZIVlkG1B2skb0ZI9oru6nqMbJxceQZlvZmcIa4oxvS1oaMTKw2DJnCv97gLm57P/YvRZ8eUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.1.10",
+        "@storybook/csf-plugin": "10.1.11",
         "@storybook/icons": "^2.0.0",
-        "@storybook/react-dom-shim": "10.1.10",
+        "@storybook/react-dom-shim": "10.1.11",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -6912,7 +6910,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.1.10"
+        "storybook": "^10.1.11"
       }
     },
     "node_modules/@storybook/addon-docs/node_modules/@storybook/icons": {
@@ -6927,9 +6925,9 @@
       }
     },
     "node_modules/@storybook/addon-vitest": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.1.10.tgz",
-      "integrity": "sha512-dh5ZesgvZY619nkweo9fbORQQSU0hIFQnqlcnU1DrGXumt9SzVHF3/2Lxe+HGHLHK6Sk8jZp/16BjZ/zxSG61Q==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.1.11.tgz",
+      "integrity": "sha512-YbZzeKO3v+Xr97/malT4DZIATkVZT5EHNYx3xzEfPVuk19dDETAVYXO+tzcqCQHsgdKQHkmd56vv8nN3J3/kvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6944,7 +6942,7 @@
         "@vitest/browser": "^3.0.0 || ^4.0.0",
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/runner": "^3.0.0 || ^4.0.0",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "vitest": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -6974,13 +6972,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.1.10.tgz",
-      "integrity": "sha512-6m6zOyDhHLynv3lvkH70s1YoIkIFPhbpGsBKvHchRLrZLe8hCPeafIFLfZRPoD4yIPwBS6rWbjMsSvBMFlR+ag==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.1.11.tgz",
+      "integrity": "sha512-MMD09Ap7FyzDfWG961pkIMv/w684XXe1bBEi+wCEpHxvrgAd3j3A9w/Rqp9Am2uRDPCEdi1QgSzS3SGW3aGThQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.1.10",
+        "@storybook/csf-plugin": "10.1.11",
         "@vitest/mocker": "3.2.4",
         "ts-dedent": "^2.0.0"
       },
@@ -6989,7 +6987,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -7044,13 +7042,13 @@
       }
     },
     "node_modules/@storybook/core": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.5.8.tgz",
-      "integrity": "sha512-OT02DQhkGpBgn5P+nZOZmbzxqubC4liVqbhpjp/HOGi5cOA3+fCJzDJeSDTu+pPh7dZnopC4XnR+5dWjtOJHdA==",
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
+      "integrity": "sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf": "0.1.12",
+        "@storybook/theming": "8.6.15",
         "better-opn": "^3.0.2",
         "browser-assert": "^1.2.1",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
@@ -7075,20 +7073,52 @@
         }
       }
     },
-    "node_modules/@storybook/core/node_modules/@storybook/csf": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.12.tgz",
-      "integrity": "sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==",
+    "node_modules/@storybook/core/node_modules/@storybook/theming": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
+      "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
       "dev": true,
       "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/storybook": {
+      "version": "8.6.15",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.15.tgz",
+      "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "type-fest": "^2.19.0"
+        "@storybook/core": "8.6.15"
+      },
+      "bin": {
+        "getstorybook": "bin/index.cjs",
+        "sb": "bin/index.cjs",
+        "storybook": "bin/index.cjs"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.1.10.tgz",
-      "integrity": "sha512-2dri4TRU8uuj/skmx/ZBw+GnnXf8EZHiMDMeijVRdBQtYFWPeoYzNIrGRpNfbuGpnDP0dcxrqti/TsedoxwFkA==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.1.11.tgz",
+      "integrity": "sha512-Ant0NhgqHKzQsseeVTSetZCuDHHs0W2HRkHt51Kg/sUl0T/sDtfVA+fWZT8nGzGZqYSFkxqYPWjauPmIhPtaRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7101,7 +7131,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "vite": "*",
         "webpack": "*"
       },
@@ -7165,15 +7195,15 @@
       }
     },
     "node_modules/@storybook/nextjs-vite": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/nextjs-vite/-/nextjs-vite-10.1.10.tgz",
-      "integrity": "sha512-u10mQn4/FzJUA2r2zP/j1gzJ8cWhl+Wf3ZFy71c3DsXpg08KWMblO6ITyvI97lCvHnIIoetUmnb0FyL/6a9YZQ==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/nextjs-vite/-/nextjs-vite-10.1.11.tgz",
+      "integrity": "sha512-IOX1GRWPfc6KuXGNM21TAP2UfwjVxg2Neb6f1GciPvMmwpN+1FaDn+TS1DGhXWofBcUW4RLdgzCDsyB2eXbq/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "10.1.10",
-        "@storybook/react": "10.1.10",
-        "@storybook/react-vite": "10.1.10",
+        "@storybook/builder-vite": "10.1.11",
+        "@storybook/react": "10.1.11",
+        "@storybook/react-vite": "10.1.11",
         "styled-jsx": "5.1.6",
         "vite-plugin-storybook-nextjs": "^3.1.0"
       },
@@ -7185,7 +7215,7 @@
         "next": "^14.1.0 || ^15.0.0 || ^16.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
@@ -7195,14 +7225,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.1.10.tgz",
-      "integrity": "sha512-9Rpr8/wX0p5/EaulrxpqrjKjhGaA/Ab9HgxzTqs2Shz0gvMAQHoiRnTEp7RCCkP49ruFYnIp0yGRSovu03LakQ==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.1.11.tgz",
+      "integrity": "sha512-rmMGmEwBaM2YpB8oDk2moM0MNjNMqtwyoPPZxjyruY9WVhYca8EDPGKEdRzUlb4qZJsTgLi7VU4eqg6LD/mL3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.1.10",
+        "@storybook/react-dom-shim": "10.1.11",
         "react-docgen": "^8.0.2"
       },
       "funding": {
@@ -7212,7 +7242,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -7222,9 +7252,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.1.10.tgz",
-      "integrity": "sha512-9pmUbEr1MeMHg9TG0c2jVUfHWr2AA86vqZGphY/nT6mbe/rGyWtBl5EnFLrz6WpI8mo3h+Kxs6p2oiuIYieRtw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.1.11.tgz",
+      "integrity": "sha512-o8WPhRlZbORUWG9lAgDgJP0pi905VHJUFJr1Kp8980gHqtlemtnzjPxKy5vFwj6glNhAlK8SS8OOYzWP7hloTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7234,20 +7264,20 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.1.10"
+        "storybook": "^10.1.11"
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.1.10.tgz",
-      "integrity": "sha512-6kE4/88YuwO07P0DR6caKNDNvCB/VnpimPmj4Jv6qmqrBgnoOOiXHIKyHJD+EjNyrbbwv4ygG01RVEajpjQaDA==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.1.11.tgz",
+      "integrity": "sha512-qh1BCD25nIoiDfqwha+qBkl7pcG4WuzM+c8tsE63YEm8AFIbNKg5K8lVUoclF+4CpFz7IwBpWe61YUTDfp+91w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.3",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.1.10",
-        "@storybook/react": "10.1.10",
+        "@storybook/builder-vite": "10.1.11",
+        "@storybook/react": "10.1.11",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -7261,7 +7291,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.1.10",
+        "storybook": "^10.1.11",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -20231,9 +20261,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.1.10.tgz",
-      "integrity": "sha512-oK0t0jEogiKKfv5Z1ao4Of99+xWw1TMUGuGRYDQS4kp2yyBsJQEgu7NI7OLYsCDI6gzt5p3RPtl1lqdeVLUi8A==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.1.11.tgz",
+      "integrity": "sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -76,10 +76,10 @@
     "@lingual/i18n-check": "^0.8.12",
     "@playwright/test": "^1.56.1",
     "@spotlightjs/spotlight": "^4.10.0",
-    "@storybook/addon-a11y": "^10.1.10",
-    "@storybook/addon-docs": "^10.1.10",
-    "@storybook/addon-vitest": "^10.1.10",
-    "@storybook/nextjs-vite": "^10.1.10",
+    "@storybook/addon-a11y": "^10.1.11",
+    "@storybook/addon-docs": "^10.1.11",
+    "@storybook/addon-vitest": "^10.1.11",
+    "@storybook/nextjs-vite": "^10.1.11",
     "@tailwindcss/postcss": "^4.1.16",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -106,7 +106,7 @@
     "rimraf": "^6.1.2",
     "sass": "^1.93.3",
     "semantic-release": "^25.0.1",
-    "storybook": "^10.1.10",
+    "storybook": "^10.1.11",
     "tailwindcss": "^4.1.16",
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^5.1.4",
@@ -127,7 +127,13 @@
     "@types/localforage": "npm:noop@1.0.1",
     "semver-diff": "npm:noop@1.0.1",
     "@esbuild-kit/esm-loader": "npm:noop@1.0.1",
-    "@esbuild-kit/core-utils": "npm:noop@1.0.1"
+    "@esbuild-kit/core-utils": "npm:noop@1.0.1",
+    "@chromatic-com/playwright": {
+      "storybook": "^8.6.15",
+      "@storybook/addon-essentials": "^8.6.15",
+      "@storybook/manager-api": "^8.6.15",
+      "@storybook/server-webpack5": "^8.6.15"
+    }
   },
   "release": {
     "branches": [


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes a security vulnerability in Storybook 8.5.8 by upgrading main Storybook packages to 10.1.11 and adding npm overrides to force @chromatic-com/playwright to use Storybook 8.6.15 instead of the vulnerable 8.5.8 version.

# Problem

A security vulnerability exists in Storybook 8.5.8, which is introduced as a transitive dependency via `@chromatic-com/playwright@0.12.8`. The `@chromatic-com/playwright` package is pinned to Storybook `~8.5.8`, which prevents automatic upgrades to the patched version 8.6.15.

# Solution

1. **Upgraded main Storybook packages** from `^10.1.10` to `^10.1.11` (latest version)
2. **Added npm overrides** in `package.json` to force `@chromatic-com/playwright` and its nested Storybook dependencies to use `^8.6.15` (latest 8.x release) instead of `8.5.8`

This approach maintains compatibility with `@chromatic-com/playwright` while resolving the security vulnerability by using the patched 8.6.x series.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)