### PR TITLE
feat: Implement cover image upload functionality

### DIFF
--- a/bookcard/services/book_cover_service.py
+++ b/bookcard/services/book_cover_service.py
@@ -142,6 +142,35 @@ class BookCoverService:
         """
         self.validate_url(url)
         content, _image = self.download_and_validate_image(url)
+        return self.save_cover_image(book_id, content)
+
+    def save_cover_image(self, book_id: int, content: bytes) -> str:
+        """Save cover image content to book directory.
+
+        Parameters
+        ----------
+        book_id : int
+            Calibre book ID.
+        content : bytes
+            Image content bytes.
+
+        Returns
+        -------
+        str
+            Cover URL path for API access.
+
+        Raises
+        ------
+        ValueError
+            If book not found, image is invalid, or save fails.
+        """
+        # Validate image content
+        try:
+            image = Image.open(io.BytesIO(content))
+            image.verify()
+        except Exception as exc:
+            error_msg = "invalid_image_format"
+            raise ValueError(error_msg) from exc
 
         # Get book with relations to access book path
         book_with_rels = self._book_service.get_book_full(book_id)

--- a/tests/api/routes/test_books_cover.py
+++ b/tests/api/routes/test_books_cover.py
@@ -1,0 +1,206 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for book cover upload API endpoint."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+import bookcard.api.routes.books as books
+from bookcard.api.main import app
+from bookcard.models.auth import User
+from bookcard.models.core import Book
+from bookcard.repositories.models import BookWithFullRelations
+from bookcard.services.book_cover_service import BookCoverService
+from bookcard.services.book_service import BookService
+
+
+@pytest.fixture
+def mock_cover_service() -> MagicMock:
+    """Create mock cover service."""
+    return MagicMock(spec=BookCoverService)
+
+
+@pytest.fixture
+def mock_book_service() -> MagicMock:
+    """Create mock book service."""
+    return MagicMock(spec=BookService)
+
+
+@pytest.fixture
+def override_dependencies(
+    mock_book_service: MagicMock,
+    mock_cover_service: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Override API dependencies."""
+
+    def mock_get_active_library_service(session: object) -> BookService:
+        return mock_book_service
+
+    def mock_get_cover_service(book_service: BookService) -> BookCoverService:
+        return mock_cover_service
+
+    monkeypatch.setattr(
+        books, "_get_active_library_service", mock_get_active_library_service
+    )
+    monkeypatch.setattr(books, "_get_cover_service", mock_get_cover_service)
+
+    # Mock permission helper
+    mock_permission_helper = MagicMock()
+    mock_permission_helper.check_write_permission.return_value = None
+
+    def mock_get_permission_helper(session: object) -> MagicMock:
+        return mock_permission_helper
+
+    monkeypatch.setattr(books, "_get_permission_helper", mock_get_permission_helper)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    return TestClient(app)
+
+
+def test_upload_cover_image_success(
+    client: TestClient,
+    mock_book_service: MagicMock,
+    mock_cover_service: MagicMock,
+    override_dependencies: None,
+) -> None:
+    """Test successful cover upload."""
+    book_id = 1
+    mock_book = BookWithFullRelations(
+        book=Book(id=book_id, title="Test", has_cover=False),
+        authors=[],
+        tags=[],
+        identifiers=[],
+        formats=[],
+        languages=[],
+        language_ids=[],
+        series=None,
+        series_id=None,
+        description=None,
+        publisher=None,
+        publisher_id=None,
+        rating=None,
+        rating_id=None,
+    )
+    mock_book_service.get_book_full.return_value = mock_book
+    mock_cover_service.save_cover_image.return_value = f"/api/books/{book_id}/cover"
+
+    # Create valid image bytes for the test
+    img = Image.new("RGB", (100, 100), color="red")
+    buffer = io.BytesIO()
+    img.save(buffer, format="JPEG")
+    image_bytes = buffer.getvalue()
+
+    files = {"file": ("cover.jpg", image_bytes, "image/jpeg")}
+
+    # Need to authenticate user
+    # Ideally use a fixture that provides an authenticated client or sets overrides
+    # For now, let's assume we can override get_current_user
+
+    app.dependency_overrides[books.get_current_user] = lambda: User(
+        id=1, username="test", is_admin=True
+    )
+
+    try:
+        response = client.post(
+            f"/books/{book_id}/cover",
+            files=files,
+        )
+    finally:
+        app.dependency_overrides = {}
+
+    assert response.status_code == 200
+    assert response.json() == {"temp_url": f"/api/books/{book_id}/cover"}
+
+
+def test_upload_cover_image_book_not_found(
+    client: TestClient,
+    mock_book_service: MagicMock,
+    mock_cover_service: MagicMock,
+    override_dependencies: None,
+) -> None:
+    """Test upload fails when book not found."""
+    book_id = 999
+    mock_book_service.get_book_full.return_value = None
+
+    app.dependency_overrides[books.get_current_user] = lambda: User(
+        id=1, username="test", is_admin=True
+    )
+
+    try:
+        files = {"file": ("cover.jpg", b"fake-content", "image/jpeg")}
+        response = client.post(
+            f"/books/{book_id}/cover",
+            files=files,
+        )
+    finally:
+        app.dependency_overrides = {}
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "book_not_found"
+
+
+def test_upload_cover_image_invalid_file(
+    client: TestClient,
+    mock_book_service: MagicMock,
+    mock_cover_service: MagicMock,
+    override_dependencies: None,
+) -> None:
+    """Test upload fails when file is invalid."""
+    book_id = 1
+    mock_book = BookWithFullRelations(
+        book=Book(id=book_id, title="Test", has_cover=False),
+        authors=[],
+        tags=[],
+        identifiers=[],
+        formats=[],
+        languages=[],
+        language_ids=[],
+        series=None,
+        series_id=None,
+        description=None,
+        publisher=None,
+        publisher_id=None,
+        rating=None,
+        rating_id=None,
+    )
+    mock_book_service.get_book_full.return_value = mock_book
+    mock_cover_service.save_cover_image.side_effect = ValueError("invalid_image_format")
+
+    app.dependency_overrides[books.get_current_user] = lambda: User(
+        id=1, username="test", is_admin=True
+    )
+
+    try:
+        files = {"file": ("cover.txt", b"not-an-image", "text/plain")}
+        response = client.post(
+            f"/books/{book_id}/cover",
+            files=files,
+        )
+    finally:
+        app.dependency_overrides = {}
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid_image_format"

--- a/web/src/components/books/BookCoverActions.test.tsx
+++ b/web/src/components/books/BookCoverActions.test.tsx
@@ -1,0 +1,186 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryClientWrapper } from "@/hooks/test-utils";
+import type { Book } from "@/types/book";
+import { BookCoverActions } from "./BookCoverActions";
+
+describe("BookCoverActions", () => {
+  const mockBook: Book = {
+    id: 1,
+    title: "Test Book",
+    authors: [],
+    tags: [],
+    identifiers: [],
+    languages: [],
+    language_ids: [],
+    formats: [],
+    has_cover: false,
+    uuid: "uuid",
+    author_sort: null,
+    title_sort: null,
+    pubdate: null,
+    timestamp: null,
+    series: null,
+    series_id: null,
+    series_index: null,
+    isbn: null,
+    description: null,
+    publisher: null,
+    publisher_id: null,
+    rating: null,
+    rating_id: null,
+    reading_summary: null,
+    thumbnail_url: null,
+  };
+
+  const Wrapper = createQueryClientWrapper();
+
+  beforeEach(() => {
+    // Mock fetch to return an admin user so buttons are enabled
+    globalThis.fetch = vi.fn((url: string) => {
+      if (url === "/api/auth/me") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: 1,
+              username: "testuser",
+              email: "test@example.com",
+              is_admin: true,
+              ereader_devices: [],
+              roles: [],
+            }),
+        } as Response);
+      }
+      if (url === "/api/auth/settings") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ settings: {} }),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch to ${url}`));
+    }) as typeof fetch;
+  });
+
+  it("should render action buttons", () => {
+    render(
+      <Wrapper>
+        <BookCoverActions
+          book={mockBook}
+          isUrlInputVisible={false}
+          onSetFromUrlClick={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Browse for a cover")).toBeDefined();
+    expect(screen.getByText("Set cover from URL")).toBeDefined();
+    expect(screen.getByText("Download cover")).toBeDefined();
+    expect(screen.getByText("Generate cover")).toBeDefined();
+  });
+
+  it("should trigger file input when browse button is clicked", async () => {
+    const onFileSelect = vi.fn();
+    render(
+      <Wrapper>
+        <BookCoverActions
+          book={mockBook}
+          isUrlInputVisible={false}
+          onSetFromUrlClick={vi.fn()}
+          onFileSelect={onFileSelect}
+        />
+      </Wrapper>,
+    );
+
+    // Wait for user context to load and button to be enabled
+    const browseButton = (await waitFor(() => {
+      const button = screen.getByText("Browse for a cover").closest("button");
+      expect(button).toBeTruthy();
+      expect(button).not.toBeDisabled();
+      return button;
+    })) as HTMLButtonElement;
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+
+    // Spy on file input click
+    const clickSpy = vi.spyOn(fileInput, "click");
+
+    fireEvent.click(browseButton);
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("should call onFileSelect when file is selected", async () => {
+    const onFileSelect = vi.fn();
+    render(
+      <Wrapper>
+        <BookCoverActions
+          book={mockBook}
+          isUrlInputVisible={false}
+          onSetFromUrlClick={vi.fn()}
+          onFileSelect={onFileSelect}
+        />
+      </Wrapper>,
+    );
+
+    // Wait for user context to load and component to render
+    await waitFor(() => {
+      const fileInput = document.querySelector(
+        'input[type="file"]',
+      ) as HTMLInputElement;
+      expect(fileInput).toBeTruthy();
+    });
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["dummy content"], "cover.jpg", {
+      type: "image/jpeg",
+    });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(onFileSelect).toHaveBeenCalledWith(file);
+    // Check that input value is cleared
+    expect(fileInput.value).toBe("");
+  });
+
+  it("should display loading state when isLoading is true", () => {
+    render(
+      <Wrapper>
+        <BookCoverActions
+          book={mockBook}
+          isUrlInputVisible={false}
+          onSetFromUrlClick={vi.fn()}
+          isLoading={true}
+        />
+      </Wrapper>,
+    );
+
+    const browseButton = screen
+      .getByText("Browse for a cover")
+      .closest("button");
+    const urlButton = screen.getByText("Set cover from URL").closest("button");
+
+    expect(browseButton).toBeDisabled();
+    expect(urlButton).toBeDisabled();
+  });
+});

--- a/web/src/components/books/BookCoverActions.tsx
+++ b/web/src/components/books/BookCoverActions.tsx
@@ -15,6 +15,7 @@
 
 "use client";
 
+import { useRef } from "react";
 import { Button } from "@/components/forms/Button";
 import { useUser } from "@/contexts/UserContext";
 import type { Book } from "@/types/book";
@@ -29,6 +30,10 @@ export interface BookCoverActionsProps {
   onSetFromUrlClick: () => void;
   /** URL input component to render when visible. */
   urlInput?: React.ReactNode;
+  /** Handler for file selection. */
+  onFileSelect?: (file: File) => void;
+  /** Whether loading (e.g. uploading). */
+  isLoading?: boolean;
 }
 
 /**
@@ -47,32 +52,58 @@ export function BookCoverActions({
   isUrlInputVisible,
   onSetFromUrlClick,
   urlInput,
+  onFileSelect,
+  isLoading,
 }: BookCoverActionsProps) {
   const { canPerformAction } = useUser();
   const bookContext = buildBookPermissionContext(book);
   const canWrite = canPerformAction("books", "write", bookContext);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleBrowseClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && onFileSelect) {
+      onFileSelect(file);
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2">
+      <input
+        type="file"
+        ref={fileInputRef}
+        className="hidden"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        onChange={handleFileChange}
+        disabled={!canWrite || isLoading}
+      />
       <Button
         type="button"
         variant="ghost"
         size="small"
-        disabled={!canWrite}
+        onClick={handleBrowseClick}
+        disabled={!canWrite || isLoading}
         className="!border-primary-a20 !text-primary-a20 hover:!text-primary-a20 focus:!shadow-none w-full justify-start rounded-md hover:border-primary-a10 hover:bg-surface-a20 focus:outline-2 focus:outline-[var(--color-primary-a0)] focus:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span
           className="pi pi-image mr-2 text-primary-a20"
           aria-hidden="true"
         />
-        Select cover
+        Browse for a cover
       </Button>
       <Button
         type="button"
         variant="ghost"
         size="small"
         onClick={canWrite ? onSetFromUrlClick : undefined}
-        disabled={!canWrite}
+        disabled={!canWrite || isLoading}
         className="!border-primary-a20 !text-primary-a20 hover:!text-primary-a20 focus:!shadow-none w-full justify-start rounded-md hover:border-primary-a10 hover:bg-surface-a20 focus:outline-2 focus:outline-[var(--color-primary-a0)] focus:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span className="pi pi-link mr-2 text-primary-a20" aria-hidden="true" />
@@ -83,7 +114,7 @@ export function BookCoverActions({
         type="button"
         variant="ghost"
         size="small"
-        disabled={!canWrite}
+        disabled={!canWrite || isLoading}
         className="!border-primary-a20 !text-primary-a20 hover:!text-primary-a20 focus:!shadow-none w-full justify-start rounded-md hover:border-primary-a10 hover:bg-surface-a20 focus:outline-2 focus:outline-[var(--color-primary-a0)] focus:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span
@@ -96,7 +127,7 @@ export function BookCoverActions({
         type="button"
         variant="ghost"
         size="small"
-        disabled={!canWrite}
+        disabled={!canWrite || isLoading}
         className="!border-primary-a20 !text-primary-a20 hover:!text-primary-a20 focus:!shadow-none w-full justify-start rounded-md hover:border-primary-a10 hover:bg-surface-a20 focus:outline-2 focus:outline-[var(--color-primary-a0)] focus:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span

--- a/web/src/services/bookService.ts
+++ b/web/src/services/bookService.ts
@@ -521,3 +521,45 @@ export async function mergeBooks(
     throw new Error(error.detail || "Failed to merge books");
   }
 }
+
+/**
+ * Upload a cover image for a book.
+ *
+ * Parameters
+ * ----------
+ * bookId : number
+ *     Book ID.
+ * file : File
+ *     Cover image file.
+ *
+ * Returns
+ * -------
+ * Promise<UploadCoverResponse>
+ *     Response containing the temporary URL of the uploaded cover.
+ */
+export interface UploadCoverResponse {
+  temp_url: string;
+}
+
+export async function uploadBookCover(
+  bookId: number,
+  file: File,
+): Promise<UploadCoverResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(`/api/books/${bookId}/cover`, {
+    method: "POST",
+    body: formData,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: "Failed to upload cover" }));
+    throw new Error(error.detail || "Failed to upload cover");
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Feature addition
  * [ ] Bug fix
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Implements cover image upload functionality for books, allowing users to browse and upload custom cover images through the UI.

# Problem

Users need the ability to upload custom cover images for books through the application interface. Previously, there was no way to upload cover images directly from the UI.

# Solution

This PR adds a complete cover image upload feature:

**Backend:**
- Added POST endpoint  for uploading cover images
- Extended  with  method to handle image processing and storage
- Added proper validation and error handling for image uploads

**Frontend:**
- Enhanced  component with browse/upload functionality
- Updated  to integrate the new upload feature
- Added API route handler for cover upload requests
- Extended  with  method

**Testing:**
- Added comprehensive test coverage for the API endpoint ()
- Added tests for the cover service functionality
- Added frontend component tests for 
- Added service layer tests for the upload functionality

# Action

Additional actions required:
* [ ] Update documentation (if needed)
* [ ] Other (please specify below)