### PR TITLE
feat: allow clearing SMTP password for servers without authentication

### DIFF
--- a/bookcard/api/schemas/auth.py
+++ b/bookcard/api/schemas/auth.py
@@ -489,6 +489,7 @@ class EmailServerConfigRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int | None = None
+    has_smtp_password: bool = False
     server_type: EmailServerType
     smtp_host: str | None = None
     smtp_port: int | None = None

--- a/bookcard/models/config.py
+++ b/bookcard/models/config.py
@@ -158,6 +158,11 @@ class EmailServerConfig(SQLModel, table=True):
         sa_column_kwargs={"onupdate": lambda: datetime.now(UTC)},
     )
 
+    @property
+    def has_smtp_password(self) -> bool:
+        """Check if an SMTP password is set."""
+        return bool(self.smtp_password)
+
 
 class Library(SQLModel, table=True):
     """Calibre library configuration.

--- a/bookcard/services/auth_service.py
+++ b/bookcard/services/auth_service.py
@@ -334,6 +334,25 @@ class AuthService:
 
         return config
 
+    def _apply_smtp_password(self, config: EmailServerConfig, password: str) -> None:
+        """Apply SMTP password configuration.
+
+        Parameters
+        ----------
+        config : EmailServerConfig
+            Configuration object to update.
+        password : str
+            The new password to set.
+        """
+        if len(password) == 0:
+            # Clear password
+            config.smtp_password = None
+        # Encrypt password before storing
+        elif self._encryptor is not None:
+            config.smtp_password = self._encryptor.encrypt(password)
+        else:
+            config.smtp_password = password
+
     def _apply_smtp_config(
         self,
         config: EmailServerConfig,
@@ -367,11 +386,7 @@ class AuthService:
         if smtp_username is not None:
             config.smtp_username = smtp_username
         if smtp_password is not None:
-            # Encrypt password before storing
-            if self._encryptor is not None:
-                config.smtp_password = self._encryptor.encrypt(smtp_password)
-            else:
-                config.smtp_password = smtp_password
+            self._apply_smtp_password(config, smtp_password)
         if smtp_use_tls is not None:
             config.smtp_use_tls = smtp_use_tls
         if smtp_use_ssl is not None:

--- a/web/src/components/admin/email/SmtpFields.test.tsx
+++ b/web/src/components/admin/email/SmtpFields.test.tsx
@@ -1,0 +1,121 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EmailServerConfigFormData } from "@/hooks/useEmailServerConfig";
+import { SmtpFields } from "./SmtpFields";
+
+// Helper to create default form data
+const createFormData = (
+  overrides: Partial<EmailServerConfigFormData> = {},
+): EmailServerConfigFormData => ({
+  server_type: "smtp",
+  smtp_host: "smtp.example.com",
+  smtp_port: 587,
+  smtp_username: "user@example.com",
+  smtp_password: undefined,
+  smtp_use_tls: true,
+  smtp_use_ssl: false,
+  smtp_from_email: "sender@example.com",
+  smtp_from_name: "Sender",
+  max_email_size_mb: 25,
+  gmail_token: null,
+  enabled: true,
+  ...overrides,
+});
+
+describe("SmtpFields", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders all SMTP fields", () => {
+    const formData = createFormData();
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    expect(screen.getByLabelText("SMTP Host")).toBeInTheDocument();
+    expect(screen.getByLabelText("SMTP Port")).toBeInTheDocument();
+    expect(screen.getByLabelText("Max Email Size (MB)")).toBeInTheDocument();
+    expect(screen.getByLabelText("SMTP Username")).toBeInTheDocument();
+    expect(screen.getByLabelText("SMTP Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("TLS")).toBeInTheDocument();
+    expect(screen.getByLabelText("SSL")).toBeInTheDocument();
+    expect(screen.getByLabelText("From Email")).toBeInTheDocument();
+  });
+
+  it("calls onFieldChange when password input changes", () => {
+    const formData = createFormData();
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    const passwordInput = screen.getByLabelText("SMTP Password");
+    fireEvent.change(passwordInput, { target: { value: "newpassword" } });
+
+    expect(onFieldChange).toHaveBeenCalledWith("smtp_password", "newpassword");
+  });
+
+  it("calls onFieldChange with empty string when password is cleared", () => {
+    const formData = createFormData({ smtp_password: "oldpassword" });
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    const passwordInput = screen.getByLabelText("SMTP Password");
+    fireEvent.change(passwordInput, { target: { value: "" } });
+
+    expect(onFieldChange).toHaveBeenCalledWith("smtp_password", "");
+  });
+
+  it("renders password field with value when provided", () => {
+    const formData = createFormData({ smtp_password: "existingpassword" });
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    const passwordInput = screen.getByLabelText(
+      "SMTP Password",
+    ) as HTMLInputElement;
+    expect(passwordInput.value).toBe("existingpassword");
+  });
+
+  it("renders empty password field when value is undefined", () => {
+    const formData = createFormData({ smtp_password: undefined });
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    const passwordInput = screen.getByLabelText(
+      "SMTP Password",
+    ) as HTMLInputElement;
+    expect(passwordInput.value).toBe("");
+  });
+
+  it("renders placeholder for password field", () => {
+    const formData = createFormData();
+    const onFieldChange = vi.fn();
+
+    render(<SmtpFields formData={formData} onFieldChange={onFieldChange} />);
+
+    const passwordInput = screen.getByLabelText("SMTP Password");
+    expect(passwordInput).toHaveAttribute(
+      "placeholder",
+      "Password (leave blank for no authentication)",
+    );
+  });
+});

--- a/web/src/components/admin/email/SmtpFields.tsx
+++ b/web/src/components/admin/email/SmtpFields.tsx
@@ -92,10 +92,8 @@ export function SmtpFields({ formData, onFieldChange }: SmtpFieldsProps) {
           label="SMTP Password"
           type="password"
           value={formData.smtp_password || ""}
-          onChange={(e) =>
-            onFieldChange("smtp_password", e.target.value || undefined)
-          }
-          placeholder="Leave blank to keep current password"
+          onChange={(e) => onFieldChange("smtp_password", e.target.value)}
+          placeholder="Password (leave blank for no authentication)"
         />
       </div>
 

--- a/web/src/services/emailServerConfigService.test.ts
+++ b/web/src/services/emailServerConfigService.test.ts
@@ -77,6 +77,7 @@ function createMockConfig(
     smtp_use_ssl: false,
     smtp_from_email: "from@example.com",
     smtp_from_name: "Test Sender",
+    has_smtp_password: true,
     max_email_size_mb: 25,
     gmail_token: null,
     enabled: true,

--- a/web/src/services/emailServerConfigService.ts
+++ b/web/src/services/emailServerConfigService.ts
@@ -23,6 +23,7 @@
 
 export interface EmailServerConfigData {
   id: number | null;
+  has_smtp_password: boolean;
   server_type: "smtp" | "gmail";
   smtp_host: string | null;
   smtp_port: number | null;


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Allow users to clear the SMTP password when switching to a server that does not require authentication. Clearing is done by leaving the password field blank and saving; no separate "clear" button is added.

# Problem

Users who configured an email server with a password could not switch to one that does not require authentication. The UI did not offer a way to clear the stored password, and the previous placeholder ("Leave blank to keep current password") discouraged clearing.

# Solution

Resolves #71 

**Backend**
- Add `has_smtp_password` to `EmailServerConfig` (model property) and `EmailServerConfigRead` so the frontend can show a masked placeholder without exposing the password.
- In `AuthService`, introduce `_apply_smtp_password`: if the client sends an empty string, set `smtp_password` to `None`; otherwise encrypt and store the new value. The email service already supports `None` passwords.

**Frontend**
- When `has_smtp_password` is true, initialize the password field with a `PASSWORD_PLACEHOLDER` (`**********`). If the user does not change it, do not send `smtp_password` in the update payload.
- If the user clears the field, send `smtp_password: ""` so the backend clears it. If the user enters a new value, send that value.
- Change detection treats the placeholder as "unchanged" so `hasChanges` stays false when only the masked password is shown.
- Update the password input placeholder to: `Password (leave blank for no authentication)`.

**Tests**
- Backend: `test_upsert_email_server_config_clears_password`, `test_upsert_email_server_config_sets_password`.
- Frontend: `useEmailServerConfig` (placeholder init, omit-on-submit, send- empty-to-clear, change detection, no change when empty with no existing password), `SmtpFields` (rendering, `onFieldChange` for typing and clearing, placeholder text).

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)
