### PR TITLE
docs: Add TASK_RUNNER env var to .env.example

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -102,6 +102,10 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_PASSWORD=
 
+# or `thread`, used for distributed tasks; you must
+# have `ENABLE_REDIS=true`
+TASK_RUNNER=dramatiq
+
 
 # =============================================================================
 # Optional: OIDC (SSO) Authentication


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [x] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Documents the `TASK_RUNNER` environment variable in `.env.example`, which controls whether background tasks use in-process threads or Dramatiq distributed workers.

# Problem

The `TASK_RUNNER` environment variable was undocumented in `.env.example`, making it unclear to users how to enable distributed task processing (Dramatiq) for features like library scanning that require Redis-based workers.

# Solution

Added `TASK_RUNNER=dramatiq` to the Redis configuration section in `.env.example` with a comment explaining valid values (`dramatiq` or `thread`) and the dependency on `ENABLE_REDIS=true`.

# Action

Additional actions required:
* [ ] Update documentation
* [x] Other (please specify below)

N/A - documentation-only change.