### PR TITLE
feat: Allow format send priorities

### DIFF
--- a/bookcard/services/send_format_service.py
+++ b/bookcard/services/send_format_service.py
@@ -1,0 +1,172 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Send format selection service.
+
+Encapsulates both:
+- Reading the user's send-format preference ordering from settings.
+- Selecting the best available format for a book, considering device preference.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from sqlmodel import Session, select
+
+from bookcard.models.auth import UserSetting
+from bookcard.repositories import BookWithFullRelations, ereader_repository
+from bookcard.services.settings_value_codecs import (
+    decode_string_list,
+    normalize_string_list,
+)
+
+if TYPE_CHECKING:
+    from bookcard.models.auth import EReaderDevice
+
+
+class SendFormatService:
+    """Service for selecting the best format to send for a user/book/device."""
+
+    _SETTING_KEY: ClassVar[str] = "send_format_priority"
+    _DEFAULT_PRIORITY: ClassVar[tuple[str, ...]] = ("EPUB", "PDF")
+
+    def __init__(self, session: Session) -> None:  # type: ignore[type-arg]
+        """Initialize the service.
+
+        Parameters
+        ----------
+        session : Session
+            Database session used for settings and device lookups.
+        """
+        self._session = session
+
+    def get_user_format_priority(self, user_id: int) -> list[str]:
+        """Get user's preferred send format priority list.
+
+        Parameters
+        ----------
+        user_id : int
+            User identifier.
+
+        Returns
+        -------
+        list[str]
+            Ordered list of preferred formats (uppercase). Defaults to
+            ``["EPUB", "PDF"]`` if not configured or invalid.
+        """
+        stmt = select(UserSetting).where(
+            UserSetting.user_id == user_id,
+            UserSetting.key == self._SETTING_KEY,
+        )
+        setting = self._session.exec(stmt).first()
+        if setting is None or not setting.value:
+            return list(self._DEFAULT_PRIORITY)
+
+        parsed = decode_string_list(setting.value, allow_csv_fallback=True)
+        normalized = normalize_string_list(parsed, normalizer=str.upper, dedupe=True)
+        return normalized if normalized else list(self._DEFAULT_PRIORITY)
+
+    def select_format(
+        self,
+        *,
+        user_id: int,
+        to_email: str | None,
+        requested_format: str | None,
+        book_with_rels: BookWithFullRelations,
+    ) -> str | None:
+        """Select the best format to send.
+
+        Selection order:
+        1) Explicit request (payload) wins.
+        2) Device `preferred_format` if configured and available for the book.
+        3) User `send_format_priority` setting.
+        4) First available format on the book.
+
+        Parameters
+        ----------
+        user_id : int
+            User ID (device lookup and settings).
+        to_email : str | None
+            Target email; if None, default/first device is assumed.
+        requested_format : str | None
+            Explicit requested format (e.g., 'EPUB').
+        book_with_rels : BookWithFullRelations
+            Book with available formats.
+
+        Returns
+        -------
+        str | None
+            Selected format (uppercase), or None if the book has no formats.
+        """
+        if requested_format:
+            return requested_format.upper()
+
+        available = self._available_formats(book_with_rels)
+        if not available:
+            return None
+
+        device = self._resolve_device(user_id=user_id, to_email=to_email)
+        if device is not None and device.preferred_format is not None:
+            preferred = device.preferred_format.value.upper()
+            if preferred in available:
+                return preferred
+
+        priority = self.get_user_format_priority(user_id)
+        for fmt in priority:
+            fmt_upper = fmt.upper()
+            if fmt_upper in available:
+                return fmt_upper
+
+        first = (
+            str(book_with_rels.formats[0].get("format", "")).upper()
+            if book_with_rels.formats
+            else ""
+        )
+        return first or None
+
+    def _resolve_device(
+        self, *, user_id: int, to_email: str | None
+    ) -> EReaderDevice | None:
+        """Resolve the target device (if any).
+
+        Notes
+        -----
+        Production code uses a real SQLModel session. Some tests may supply a light
+        stub session; in that scenario, we skip device resolution and fall back to
+        user-level priority.
+        """
+        try:
+            repo = ereader_repository.EReaderRepository(self._session)
+            if to_email:
+                return repo.find_by_email(user_id, to_email)
+
+            device = repo.find_default(user_id)
+            if device is not None:
+                return device
+
+            devices = list(repo.find_by_user(user_id))
+            return devices[0] if devices else None
+        except AttributeError:
+            return None
+
+    @staticmethod
+    def _available_formats(book_with_rels: BookWithFullRelations) -> set[str]:
+        """Return set of available formats (uppercase)."""
+        return {
+            str(f.get("format", "")).upper()
+            for f in book_with_rels.formats
+            if isinstance(f.get("format", ""), str) and str(f.get("format", "")).strip()
+        }

--- a/bookcard/services/settings_value_codecs.py
+++ b/bookcard/services/settings_value_codecs.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Codecs for decoding user setting values.
+
+This module centralizes decoding logic for settings stored in `UserSetting.value`.
+It prevents duplicated parsing behavior across services and tasks.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def decode_string_list(
+    value: str,
+    *,
+    allow_csv_fallback: bool = True,
+) -> list[str]:
+    """Decode a setting value into a list of strings.
+
+    Supports JSON array storage (recommended) and (optionally) a comma-separated
+    fallback for backward compatibility.
+
+    Parameters
+    ----------
+    value : str
+        Raw setting value.
+    allow_csv_fallback : bool, default=True
+        Whether to fall back to comma-separated parsing if JSON decoding fails.
+
+    Returns
+    -------
+    list[str]
+        Decoded list of strings. Returns an empty list if no valid values exist.
+    """
+    try:
+        decoded = json.loads(value)
+        if isinstance(decoded, list):
+            return [v for v in decoded if isinstance(v, str)]
+    except (json.JSONDecodeError, TypeError):
+        if allow_csv_fallback:
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return []
+    else:
+        return []
+
+
+def normalize_string_list(
+    values: list[str],
+    *,
+    normalizer: Callable[[str], str] = lambda s: s,
+    dedupe: bool = True,
+) -> list[str]:
+    """Normalize a list of strings.
+
+    Parameters
+    ----------
+    values : list[str]
+        Input string list.
+    normalizer : Callable[[str], str], default=identity
+        Normalization function to apply to each value (e.g., `str.upper`).
+    dedupe : bool, default=True
+        Whether to de-duplicate values while preserving order.
+
+    Returns
+    -------
+    list[str]
+        Normalized list.
+    """
+    normalized = [normalizer(v.strip()) for v in values if v.strip()]
+    if not dedupe:
+        return normalized
+    seen: set[str] = set()
+    result: list[str] = []
+    for v in normalized:
+        if v in seen:
+            continue
+        seen.add(v)
+        result.append(v)
+    return result

--- a/bookcard/services/tasks/utils.py
+++ b/bookcard/services/tasks/utils.py
@@ -21,41 +21,6 @@ Provides shared utilities following Separation of Concerns.
 from bookcard.repositories import BookWithFullRelations
 
 
-class BookFormatResolver:
-    """Resolves the format to use for book operations.
-
-    Follows Separation of Concerns by extracting format resolution logic.
-    """
-
-    @staticmethod
-    def resolve_send_format(
-        requested_format: str | None,
-        book_with_rels: BookWithFullRelations,
-    ) -> str | None:
-        """Determine the format to send.
-
-        Parameters
-        ----------
-        requested_format : str | None
-            Explicitly requested format, if any.
-        book_with_rels : BookWithFullRelations
-            Book with its relationships.
-
-        Returns
-        -------
-        str | None
-            Uppercase format string, or None if no format available.
-        """
-        if requested_format:
-            return requested_format.upper()
-
-        if not book_with_rels.formats:
-            return None
-
-        first_format = book_with_rels.formats[0].get("format")
-        return str(first_format).upper() if first_format else None
-
-
 class AuthorExtractor:
     """Extracts author information from book data.
 

--- a/tests/services/tasks/test_email_send_task.py
+++ b/tests/services/tasks/test_email_send_task.py
@@ -497,10 +497,12 @@ class TestEmailSendTaskRun:
         ):
             task.run(worker_context)
 
-        # Verify book service was called with None values
+        # Verify book service was called with expected values.
+        # If no format is provided, the task resolves a preferred format based on
+        # user-level priority (defaulting to EPUB -> PDF -> first available).
         mock_book_service.send_book.assert_called_once()
         call_kwargs = mock_book_service.send_book.call_args[1]
         assert call_kwargs["book_id"] == 1
         assert call_kwargs["user_id"] == 1
         assert call_kwargs["to_email"] is None
-        assert call_kwargs["file_format"] is None
+        assert call_kwargs["file_format"] == "EPUB"

--- a/tests/services/test_send_format_service.py
+++ b/tests/services/test_send_format_service.py
@@ -1,0 +1,269 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for `SendFormatService`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bookcard.models.auth import EBookFormat, EReaderDevice, UserSetting
+from bookcard.models.core import Book
+from bookcard.repositories import BookWithFullRelations
+from bookcard.services.send_format_service import SendFormatService
+from tests.conftest import DummySession
+
+
+@pytest.fixture
+def session() -> DummySession:
+    """Create a dummy session with configurable exec results."""
+    return DummySession()
+
+
+@pytest.fixture
+def book() -> Book:
+    """Create a minimal book."""
+    return Book(
+        id=1,
+        title="Test Book",
+        uuid="test-uuid",
+        has_cover=False,
+        path="Author/Test Book (1)",
+    )
+
+
+def _book_with_formats(book: Book, formats: list[str]) -> BookWithFullRelations:
+    """Create `BookWithFullRelations` with specified formats."""
+    return BookWithFullRelations(
+        book=book,
+        authors=["Author One"],
+        series=None,
+        series_id=None,
+        tags=[],
+        identifiers=[],
+        description=None,
+        publisher=None,
+        publisher_id=None,
+        languages=[],
+        language_ids=[],
+        rating=None,
+        rating_id=None,
+        formats=[
+            {"format": fmt, "name": f"test.{fmt.lower()}", "size": 1000}
+            for fmt in formats
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [
+        (None, ["EPUB", "PDF"]),
+        ("", ["EPUB", "PDF"]),
+        ('["pdf","epub","pdf","  azw3  "]', ["PDF", "EPUB", "AZW3"]),
+        ("pdf, epub, pdf", ["PDF", "EPUB"]),
+        ('{"not":"a list"}', ["EPUB", "PDF"]),
+    ],
+)
+def test_get_user_format_priority_parsing(
+    session: DummySession,
+    raw_value: str | None,
+    expected: list[str],
+) -> None:
+    """User setting is parsed as JSON list or CSV; invalid defaults."""
+    if raw_value is not None:
+        setting = UserSetting(user_id=1, key="send_format_priority", value=raw_value)
+        session.add_exec_result([setting])
+    else:
+        session.add_exec_result([])
+
+    service = SendFormatService(session)  # type: ignore[arg-type]
+    assert service.get_user_format_priority(user_id=1) == expected
+
+
+@pytest.mark.parametrize(
+    ("requested_format", "expected"),
+    [
+        ("epub", "EPUB"),
+        ("PDF", "PDF"),
+        ("mobi", "MOBI"),
+    ],
+)
+def test_select_format_explicit_request_wins(
+    session: DummySession,
+    book: Book,
+    requested_format: str,
+    expected: str,
+) -> None:
+    """Explicit requested_format always wins (case-insensitive)."""
+    book_with_rels = _book_with_formats(book, ["EPUB", "PDF"])
+    service = SendFormatService(session)  # type: ignore[arg-type]
+
+    assert (
+        service.select_format(
+            user_id=1,
+            to_email="device@example.com",
+            requested_format=requested_format,
+            book_with_rels=book_with_rels,
+        )
+        == expected
+    )
+
+
+def test_select_format_returns_none_when_book_has_no_formats(
+    session: DummySession,
+    book: Book,
+) -> None:
+    """No formats => selection returns None (caller decides behavior)."""
+    book_with_rels = _book_with_formats(book, [])
+    service = SendFormatService(session)  # type: ignore[arg-type]
+    assert (
+        service.select_format(
+            user_id=1,
+            to_email=None,
+            requested_format=None,
+            book_with_rels=book_with_rels,
+        )
+        is None
+    )
+
+
+def test_select_format_device_preferred_format_used_when_available(
+    session: DummySession,
+    book: Book,
+) -> None:
+    """Device preferred_format wins over user priority when available."""
+    book_with_rels = _book_with_formats(book, ["EPUB", "PDF"])
+    device = EReaderDevice(
+        id=1,
+        user_id=1,
+        email="device@example.com",
+        device_name="My Device",
+        device_type="generic",
+        is_default=True,
+        preferred_format=EBookFormat.PDF,
+    )
+
+    repo = MagicMock()
+    repo.find_by_email.return_value = device
+    repo.find_default.return_value = None
+    repo.find_by_user.return_value = []
+
+    # If this were consulted, user priority would pick EPUB first; ensure device wins.
+    session.add_exec_result([
+        UserSetting(user_id=1, key="send_format_priority", value='["EPUB","PDF"]')
+    ])
+
+    with patch(
+        "bookcard.services.send_format_service.ereader_repository.EReaderRepository",
+        return_value=repo,
+    ):
+        service = SendFormatService(session)  # type: ignore[arg-type]
+        assert (
+            service.select_format(
+                user_id=1,
+                to_email="device@example.com",
+                requested_format=None,
+                book_with_rels=book_with_rels,
+            )
+            == "PDF"
+        )
+
+
+@pytest.mark.parametrize(
+    ("device_pref", "priority_value", "expected"),
+    [
+        # Device preference not available => use user priority
+        (EBookFormat.AZW3, '["PDF","EPUB"]', "PDF"),
+        # No matching user priority => fall back to first available
+        (EBookFormat.AZW3, '["MOBI"]', "PDF"),
+    ],
+)
+def test_select_format_falls_back_when_device_preference_unavailable(
+    session: DummySession,
+    book: Book,
+    device_pref: EBookFormat,
+    priority_value: str,
+    expected: str,
+) -> None:
+    """If device preferred format isn't present on book, use user priority then first."""
+    # First available is PDF here; keep order stable to validate fallback.
+    book_with_rels = _book_with_formats(book, ["PDF", "EPUB"])
+    device = EReaderDevice(
+        id=1,
+        user_id=1,
+        email="device@example.com",
+        device_name="My Device",
+        device_type="generic",
+        is_default=True,
+        preferred_format=device_pref,
+    )
+
+    repo = MagicMock()
+    repo.find_by_email.return_value = device
+    repo.find_default.return_value = None
+    repo.find_by_user.return_value = []
+
+    session.add_exec_result([
+        UserSetting(user_id=1, key="send_format_priority", value=priority_value)
+    ])
+
+    with patch(
+        "bookcard.services.send_format_service.ereader_repository.EReaderRepository",
+        return_value=repo,
+    ):
+        service = SendFormatService(session)  # type: ignore[arg-type]
+        assert (
+            service.select_format(
+                user_id=1,
+                to_email="device@example.com",
+                requested_format=None,
+                book_with_rels=book_with_rels,
+            )
+            == expected
+        )
+
+
+def test_select_format_uses_user_priority_when_no_device_resolves(
+    session: DummySession,
+    book: Book,
+) -> None:
+    """If device cannot be resolved, user priority decides."""
+    book_with_rels = _book_with_formats(book, ["PDF", "EPUB"])
+    session.add_exec_result([
+        UserSetting(user_id=1, key="send_format_priority", value='["EPUB","PDF"]')
+    ])
+
+    repo = MagicMock()
+    repo.find_by_email.return_value = None
+    repo.find_default.return_value = None
+    repo.find_by_user.return_value = []
+
+    with patch(
+        "bookcard.services.send_format_service.ereader_repository.EReaderRepository",
+        return_value=repo,
+    ):
+        service = SendFormatService(session)  # type: ignore[arg-type]
+        assert (
+            service.select_format(
+                user_id=1,
+                to_email="unknown@example.com",
+                requested_format=None,
+                book_with_rels=book_with_rels,
+            )
+            == "EPUB"
+        )


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Introduces a new SendFormatService that allows users to configure format send priorities, with support for device-specific preferences and user-level defaults.

# Problem

Previously, when sending books via email, the system would either use an explicitly requested format or fall back to the first available format. There was no way for users to configure a preferred format priority order (e.g., prefer EPUB over PDF), and device-specific format preferences were not considered during format selection.

# Solution

- Created  that encapsulates format selection logic with a priority hierarchy:
  1. Explicit request (payload) wins
  2. Device  if configured and available
  3. User  setting (new user preference)
  4. First available format on the book
- Introduced  module to centralize decoding of setting values (JSON arrays with CSV fallback for backward compatibility)
- Refactored  to use the new service instead of the simple  utility
- Removed  class as its functionality is now handled by the service
- Updated  to use the shared codec functions for consistency
- Added comprehensive tests for the new service
- Updated frontend component to support the new setting

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)