### PR TITLE
Split profile menu: move configurations to dedicated page and refactor menu actions

### DIFF
--- a/web/src/app/profile/configurations/page.tsx
+++ b/web/src/app/profile/configurations/page.tsx
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"use client";
+
+import { PageHeader } from "@/components/layout/PageHeader";
+import { PageLayout } from "@/components/layout/PageLayout";
+import { ConfigurationsSection } from "@/components/profile/ConfigurationsSection";
+
+/**
+ * User configurations page.
+ *
+ * Hosts the configuration tabs that were previously embedded in the profile page.
+ * Uses PageLayout for consistent sidebar and context provider setup.
+ */
+export default function ProfileConfigurationsPage() {
+  return (
+    <PageLayout>
+      <PageHeader title="Configurations" />
+      <div className="p-6 px-8">
+        <ConfigurationsSection showTitle={false} />
+      </div>
+    </PageLayout>
+  );
+}

--- a/web/src/components/layout/ProfileButton.tsx
+++ b/web/src/components/layout/ProfileButton.tsx
@@ -15,7 +15,6 @@
 
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { useUser } from "@/contexts/UserContext";
 import { ProfileMenu } from "./ProfileMenu";
@@ -29,7 +28,6 @@ import { Tooltip } from "./Tooltip";
  */
 export function ProfileButton() {
   const { user } = useUser();
-  const router = useRouter();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [cursorPosition, setCursorPosition] = useState<{
@@ -59,26 +57,6 @@ export function ProfileButton() {
     setIsMenuOpen(false);
     setCursorPosition(null);
   }, []);
-
-  const handleViewProfile = useCallback(() => {
-    router.push("/profile");
-  }, [router]);
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await fetch("/api/auth/logout", {
-        method: "POST",
-        credentials: "include",
-      });
-      // Redirect to login page
-      router.push("/login");
-      router.refresh();
-    } catch {
-      // Even if logout fails, redirect to login
-      router.push("/login");
-      router.refresh();
-    }
-  }, [router]);
 
   // Use shared profile picture URL from context (fetched once globally)
   const { profilePictureUrl } = useUser();
@@ -125,8 +103,6 @@ export function ProfileButton() {
         buttonRef={buttonRef}
         cursorPosition={cursorPosition}
         user={user}
-        onViewProfile={handleViewProfile}
-        onLogout={handleLogout}
       />
     </>
   );

--- a/web/src/components/layout/ProfileMenu.tsx
+++ b/web/src/components/layout/ProfileMenu.tsx
@@ -15,13 +15,11 @@
 
 "use client";
 
-import { useCallback } from "react";
 import { DropdownMenu } from "@/components/common/DropdownMenu";
 import { DropdownMenuItem } from "@/components/common/DropdownMenuItem";
-import { getToggleThemeLabel } from "@/components/profile/config/configurationConstants";
 import type { User } from "@/contexts/UserContext";
 import { useUser } from "@/contexts/UserContext";
-import { useTheme } from "@/hooks/useTheme";
+import { useProfileMenuActions } from "@/hooks/useProfileMenuActions";
 
 export interface ProfileMenuProps {
   /** Whether the menu is open. */
@@ -34,10 +32,6 @@ export interface ProfileMenuProps {
   cursorPosition: { x: number; y: number } | null;
   /** User data to display in header. */
   user: User | null;
-  /** Callback when View profile is clicked. */
-  onViewProfile?: () => void;
-  /** Callback when Logout is clicked. */
-  onLogout?: () => void;
 }
 
 /**
@@ -54,32 +48,12 @@ export function ProfileMenu({
   buttonRef,
   cursorPosition,
   user,
-  onViewProfile,
-  onLogout,
 }: ProfileMenuProps) {
-  const handleViewProfileClick = useCallback(() => {
-    if (onViewProfile) {
-      onViewProfile();
-    }
-    onClose();
-  }, [onViewProfile, onClose]);
-
-  const handleLogoutClick = useCallback(() => {
-    if (onLogout) {
-      onLogout();
-    }
-    onClose();
-  }, [onLogout, onClose]);
+  const { onViewProfile, items } = useProfileMenuActions({ onClose });
 
   const displayName = user?.full_name ?? user?.username ?? "User";
   // Use shared profile picture URL from context (fetched once globally)
   const { profilePictureUrl } = useUser();
-  const { theme, toggleTheme } = useTheme();
-
-  const handleThemeToggle = useCallback(() => {
-    toggleTheme();
-    onClose();
-  }, [toggleTheme, onClose]);
 
   return (
     <DropdownMenu
@@ -94,7 +68,7 @@ export function ProfileMenu({
         <button
           type="button"
           className="flex w-full cursor-pointer flex-col items-center gap-2 border-0 bg-transparent p-0 text-center"
-          onClick={handleViewProfileClick}
+          onClick={onViewProfile}
           aria-label="View profile"
         >
           {/* Profile picture or placeholder */}
@@ -123,24 +97,9 @@ export function ProfileMenu({
         </button>
       </div>
       {/* Menu items */}
-      <DropdownMenuItem
-        icon="pi pi-id-card"
-        label="View profile"
-        onClick={handleViewProfileClick}
-        className="cursor-pointer"
-      />
-      <DropdownMenuItem
-        icon={theme === "dark" ? "pi pi-sun" : "pi pi-moon"}
-        label={getToggleThemeLabel(theme)}
-        onClick={handleThemeToggle}
-        className="cursor-pointer"
-      />
-      <DropdownMenuItem
-        icon="pi pi-sign-out"
-        label="Logout"
-        onClick={handleLogoutClick}
-        className="cursor-pointer"
-      />
+      {items.map((item) => (
+        <DropdownMenuItem key={item.label} {...item} />
+      ))}
     </DropdownMenu>
   );
 }

--- a/web/src/components/profile/ConfigurationsSection.tsx
+++ b/web/src/components/profile/ConfigurationsSection.tsx
@@ -16,7 +16,7 @@
 "use client";
 
 import { useState } from "react";
-import { SettingsProvider, useSettings } from "@/contexts/SettingsContext";
+import { SettingsProvider } from "@/contexts/SettingsContext";
 import { useTabScroll } from "@/hooks/useTabScroll";
 import { cn } from "@/libs/utils";
 import { BlurAfterClickProvider } from "./BlurAfterClickContext";
@@ -67,9 +67,8 @@ function TabContent({ children }: { children: React.ReactNode[] }) {
  * Follows IOC by using configurable scroll hook.
  * Follows SOC by delegating scroll behavior to useTabScroll hook.
  */
-function ConfigurationsSectionContent() {
+function ConfigurationsSectionContent({ showTitle }: { showTitle: boolean }) {
   const [activeTab, setActiveTab] = useState<TabId>(DEFAULT_TAB_ID);
-  const { isSaving } = useSettings();
   const { headerRef, contentRef, scrollToBottom } = useTabScroll();
 
   /**
@@ -134,27 +133,30 @@ function ConfigurationsSectionContent() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2">
-        <h2 ref={headerRef} className="m-0 font-semibold text-text-a0 text-xl">
-          Configurations
-        </h2>
-        {isSaving && (
-          <div className="flex items-center gap-2 text-sm text-text-a30">
-            <i className="pi pi-spin pi-spinner" aria-hidden="true" />
-            <span>Saving...</span>
-          </div>
+      <div
+        className={cn("flex items-center gap-2", !showTitle && "justify-end")}
+      >
+        {showTitle ? (
+          <h2
+            ref={headerRef}
+            className="m-0 font-semibold text-text-a0 text-xl"
+          >
+            Configurations
+          </h2>
+        ) : (
+          <div ref={headerRef} className="h-0 w-0" aria-hidden="true" />
         )}
       </div>
 
       <BlurAfterClickProvider>
         <div className="flex flex-col gap-6">
-          <div className="flex gap-2 border-[var(--color-surface-a20)] border-b">
+          <div className="flex flex-col gap-2 border-[var(--color-surface-a20)] border-b sm:flex-row sm:flex-wrap">
             {CONFIGURATION_TABS.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
                 className={cn(
-                  "-mb-px relative cursor-pointer border-0 border-transparent border-b-2 bg-transparent px-6 py-3 font-medium text-sm text-text-a30 transition-[color,border-color] duration-200",
+                  "sm:-mb-px relative w-full max-w-[200px] cursor-pointer border-0 border-transparent border-b-2 bg-transparent px-4 py-2 font-medium text-sm text-text-a30 transition-[color,border-color] duration-200 sm:w-auto sm:px-6 sm:py-3",
                   "hover:text-text-a10",
                   activeTab === tab.id &&
                     "border-b-[var(--color-primary-a0)] text-text-a0",
@@ -188,15 +190,19 @@ function ConfigurationsSectionContent() {
  * ----------
  * debounceMs : number
  *     Debounce delay in milliseconds for settings updates (default: 500).
+ * showTitle : boolean
+ *     Whether to show the section title header (default: true).
  */
 export function ConfigurationsSection({
   debounceMs = 300,
+  showTitle = true,
 }: {
   debounceMs?: number;
+  showTitle?: boolean;
 }) {
   return (
     <SettingsProvider debounceMs={debounceMs}>
-      <ConfigurationsSectionContent />
+      <ConfigurationsSectionContent showTitle={showTitle} />
     </SettingsProvider>
   );
 }

--- a/web/src/components/profile/ProfileSettings.tsx
+++ b/web/src/components/profile/ProfileSettings.tsx
@@ -15,7 +15,6 @@
 
 "use client";
 
-import { ConfigurationsSection } from "./ConfigurationsSection";
 import { DevicesSection } from "./DevicesSection";
 import { useUserProfile } from "./hooks/useUserProfile";
 import { ProfileSection } from "./ProfileSection";
@@ -23,7 +22,7 @@ import { ProfileSection } from "./ProfileSection";
 /**
  * Profile settings component.
  *
- * Displays user information, devices, and configuration preferences.
+ * Displays user information and devices (including send format priority).
  * Follows SRP by delegating to specialized section components.
  */
 export function ProfileSettings() {
@@ -50,7 +49,6 @@ export function ProfileSettings() {
       <div className="flex flex-col gap-8">
         <ProfileSection user={user} />
         <DevicesSection devices={user.ereader_devices} />
-        <ConfigurationsSection />
       </div>
     </div>
   );

--- a/web/src/contexts/GlobalMessageContext.tsx
+++ b/web/src/contexts/GlobalMessageContext.tsx
@@ -28,7 +28,7 @@ export interface ShowMessageOptions {
   durationMs?: number;
 }
 
-interface GlobalMessageContextValue {
+export interface GlobalMessageContextValue {
   /**Current list of global messages. */
   messages: GlobalMessage[];
   /**
@@ -176,4 +176,22 @@ export function useGlobalMessages(): GlobalMessageContextValue {
     );
   }
   return context;
+}
+
+/**
+ * Hook to optionally access the global message context.
+ *
+ * Unlike `useGlobalMessages`, this hook does not throw when used outside of a
+ * `GlobalMessageProvider`. This is useful for code paths (and tests) where
+ * global messaging is an optional enhancement.
+ *
+ * Returns
+ * -------
+ * GlobalMessageContextValue | undefined
+ *     The global message context if available, otherwise undefined.
+ */
+export function useOptionalGlobalMessages():
+  | GlobalMessageContextValue
+  | undefined {
+  return useContext(GlobalMessageContext);
 }

--- a/web/src/hooks/useProfileMenuActions.tsx
+++ b/web/src/hooks/useProfileMenuActions.tsx
@@ -1,0 +1,123 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useRouter } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import { FaCog } from "react-icons/fa";
+import type { DropdownMenuItemProps } from "@/components/common/DropdownMenuItem";
+import { getToggleThemeLabel } from "@/components/profile/config/configurationConstants";
+import { useTheme } from "@/hooks/useTheme";
+
+export interface UseProfileMenuActionsOptions {
+  /** Callback when menu should be closed. */
+  onClose: () => void;
+}
+
+export interface UseProfileMenuActionsResult {
+  /** Handler for profile header and "View profile" navigation. */
+  onViewProfile: () => void;
+  /** Menu items to render in the profile dropdown. */
+  items: DropdownMenuItemProps[];
+}
+
+/**
+ * Custom hook for profile menu actions.
+ *
+ * Provides handlers and menu item definitions for the profile dropdown.
+ * Follows SRP by managing only menu action handlers and their presentation data.
+ * Follows SOC by keeping ProfileMenu as a render-only wrapper.
+ *
+ * Parameters
+ * ----------
+ * options : UseProfileMenuActionsOptions
+ *     Configuration including close callback.
+ *
+ * Returns
+ * -------
+ * UseProfileMenuActionsResult
+ *     Action handlers and menu item definitions.
+ */
+export function useProfileMenuActions({
+  onClose,
+}: UseProfileMenuActionsOptions): UseProfileMenuActionsResult {
+  const router = useRouter();
+  const { theme, toggleTheme } = useTheme();
+
+  const onViewProfile = useCallback(() => {
+    router.push("/profile");
+    onClose();
+  }, [onClose, router]);
+
+  const onViewConfigurations = useCallback(() => {
+    router.push("/profile/configurations");
+    onClose();
+  }, [onClose, router]);
+
+  const onToggleTheme = useCallback(() => {
+    toggleTheme();
+    onClose();
+  }, [onClose, toggleTheme]);
+
+  const onLogout = useCallback(async () => {
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } finally {
+      // Even if logout fails, redirect to login.
+      router.push("/login");
+      router.refresh();
+      onClose();
+    }
+  }, [onClose, router]);
+
+  const items: DropdownMenuItemProps[] = useMemo(
+    () => [
+      {
+        icon: "pi pi-id-card",
+        label: "View profile",
+        onClick: onViewProfile,
+        className: "cursor-pointer",
+      },
+      {
+        icon: <FaCog className="text-base" aria-hidden="true" />,
+        label: "Configurations",
+        onClick: onViewConfigurations,
+        className: "cursor-pointer",
+      },
+      {
+        icon: theme === "dark" ? "pi pi-sun" : "pi pi-moon",
+        label: getToggleThemeLabel(theme),
+        onClick: onToggleTheme,
+        className: "cursor-pointer",
+      },
+      {
+        icon: "pi pi-sign-out",
+        label: "Logout",
+        onClick: () => {
+          void onLogout();
+        },
+        className: "cursor-pointer",
+      },
+    ],
+    [onLogout, onToggleTheme, onViewConfigurations, onViewProfile, theme],
+  );
+
+  return {
+    onViewProfile,
+    items,
+  };
+}


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Feature addition
  * [x] Refactoring
  * [ ] Bug fix
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Splits the busy profile page by moving configuration tabs to a dedicated  page, adds a Configurations menu item with gear icon, refactors ProfileMenu to follow SRP/SOC patterns, and replaces inline save indicators with global toast notifications.

# Problem

Closes #85 

- The profile page () was overloaded with profile info, devices, and all configuration tabs, making it feel cluttered
- ProfileMenu had action logic embedded, causing prop-drilling and making it hard to add new menu items
- Inline "Saving..." spinner in ConfigurationsSection was an antipattern and didn't work when the title was hidden on the new dedicated page
- Tests were failing because UserProvider now uses global messages but tests don't always wrap with GlobalMessageProvider

# Solution

- **New page**: Created  that hosts ConfigurationsSection with PageHeader
- **Profile page cleanup**: Removed ConfigurationsSection from ProfileSettings, keeping only profile info and devices (including send format priority)
- **Menu enhancement**: Added "Configurations" menu item (FaCog icon) under "View profile" in the dropdown
- **Refactoring**: Extracted all ProfileMenu action logic into  hook (following BookCardMenu pattern), making ProfileMenu a thin render-only wrapper
- **Toast notifications**: Replaced inline save spinner with global toast notifications (success: "Settings saved: {key} -> {value}", error: "{message}. Will retry automatically.")
- **Test compatibility**: Added  hook so UserProvider can work in tests without GlobalMessageProvider
- **Responsive tabs**: Made configuration tabs stack vertically on small screens, horizontal on larger screens
- **UI polish**: Added max-width constraint to tab buttons

# Action

Additional actions required:
* [ ] Update documentation (if needed)
* [ ] Other (please specify below)