### PR TITLE
feat: Add metadata DB backup scheduled job

### DIFF
--- a/bookcard/db/migrations/versions/b82a45801b30_seed_metadata_backup_job.py
+++ b/bookcard/db/migrations/versions/b82a45801b30_seed_metadata_backup_job.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Seed metadata backup job.
+
+Revision ID: b82a45801b30
+Revises: a82a45801b29
+Create Date: 2025-01-25 01:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.sql import column, table
+
+# revision identifiers, used by Alembic.
+revision = "b82a45801b30"
+down_revision = "a82a45801b29"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema.
+
+    Idempotently seeds the metadata backup scheduled job.
+    """
+    connection = op.get_bind()
+
+    # Get existing job names
+    result = connection.execute(text("SELECT job_name FROM scheduled_job_definitions"))
+    existing_jobs = {row[0] for row in result.fetchall()}
+
+    # Define table
+    jobs_table = table(
+        "scheduled_job_definitions",
+        column("job_name", sa.String),
+        column("task_type", sa.String),
+        column("cron_expression", sa.String),
+        column("enabled", sa.Boolean),
+        column("description", sa.String),
+        column("arguments", sa.JSON),
+        column("created_at", sa.DateTime),
+        column("updated_at", sa.DateTime),
+    )
+
+    job_name = "metadata_backup_all_libraries"
+
+    if job_name not in existing_jobs:
+        op.execute(
+            jobs_table.insert().values(
+                job_name=job_name,
+                task_type="METADATA_BACKUP",
+                cron_expression="0 0 * * *",  # Daily at 00:00
+                enabled=True,
+                description="Backup metadata.db for all libraries",
+                arguments={},
+                created_at=sa.func.now(),
+                updated_at=sa.func.now(),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema.
+
+    Removes the metadata backup job.
+    """
+    jobs_table = table(
+        "scheduled_job_definitions",
+        column("job_name", sa.String),
+    )
+
+    op.execute(
+        jobs_table.delete().where(
+            jobs_table.c.job_name == "metadata_backup_all_libraries"
+        )
+    )

--- a/bookcard/services/tasks/factory.py
+++ b/bookcard/services/tasks/factory.py
@@ -45,6 +45,7 @@ from bookcard.services.tasks.indexer_health_check_task import (
 from bookcard.services.tasks.ingest_book_task import IngestBookTask
 from bookcard.services.tasks.ingest_discovery_task import IngestDiscoveryTask
 from bookcard.services.tasks.library_scan_task import LibraryScanTask
+from bookcard.services.tasks.metadata_db_backup_task import MetadataDbBackupTask
 from bookcard.services.tasks.multi_upload_task import MultiBookUploadTask
 from bookcard.services.tasks.openlibrary import OpenLibraryDumpIngestTask
 from bookcard.services.tasks.openlibrary_dump_download_task import (
@@ -257,3 +258,4 @@ _registry.register(TaskType.INGEST_BOOK, IngestBookTask)
 _registry.register(TaskType.PVR_DOWNLOAD_MONITOR, DownloadMonitorTask)
 _registry.register(TaskType.PROWLARR_SYNC, ProwlarrSyncTask)
 _registry.register(TaskType.INDEXER_HEALTH_CHECK, IndexerHealthCheckTask)
+_registry.register(TaskType.METADATA_BACKUP, MetadataDbBackupTask)

--- a/bookcard/services/tasks/metadata_db_backup_task.py
+++ b/bookcard/services/tasks/metadata_db_backup_task.py
@@ -1,0 +1,167 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Metadata DB backup task implementation."""
+
+import logging
+import re
+import shutil
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bookcard.repositories.library_repository import LibraryRepository
+from bookcard.services.tasks.base import BaseTask
+
+if TYPE_CHECKING:
+    from bookcard.models.config import Library
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataDbBackupTask(BaseTask):
+    """Task for backing up library metadata databases.
+
+    Backs up the metadata.db (or configured file) for all libraries,
+    keeping a configurable number of recent backups (default 100).
+    """
+
+    def run(self, worker_context: dict[str, Any]) -> None:
+        """Execute the backup task.
+
+        Parameters
+        ----------
+        worker_context : dict[str, Any]
+            Worker context containing the database session.
+        """
+        session = worker_context["session"]
+        library_repo = LibraryRepository(session)
+
+        # 1. Find all configured libraries
+        libraries = list(library_repo.list())
+        if not libraries:
+            logger.info("No libraries configured for backup.")
+            return
+
+        total_libraries = len(libraries)
+        logger.info("Starting metadata backup for %d libraries", total_libraries)
+
+        success_count = 0
+        fail_count = 0
+
+        for i, library in enumerate(libraries):
+            try:
+                self._backup_library(library)
+                success_count += 1
+            except Exception:
+                logger.exception(
+                    "Failed to backup library '%s' (ID: %s)", library.name, library.id
+                )
+                fail_count += 1
+
+            # Update progress
+            self.update_progress((i + 1) / total_libraries)
+
+        logger.info(
+            "Metadata backup completed. Success: %d, Failed: %d",
+            success_count,
+            fail_count,
+        )
+        if fail_count > 0:
+            msg = f"Backup failed for {fail_count} libraries"
+            raise RuntimeError(msg)
+
+    def _backup_library(self, library: "Library") -> None:
+        """Create backup for a single library and rotate old backups.
+
+        Parameters
+        ----------
+        library : Library
+            Library model instance.
+        """
+        db_path_str = library.calibre_db_path
+        db_filename = library.calibre_db_file or "metadata.db"
+
+        if not db_path_str:
+            logger.warning("Library '%s' has no path configured", library.name)
+            return
+
+        db_path = Path(db_path_str) / db_filename
+
+        if not db_path.exists() or not db_path.is_file():
+            logger.warning("Database file not found at %s", db_path)
+            return
+
+        # Create backup
+        timestamp = int(time.time())
+        # Naming scheme: {stem}.{unix_ts}{suffix}.bk
+        # e.g. metadata.1737763200.db.bk
+        backup_filename = f"{db_path.stem}.{timestamp}{db_path.suffix}.bk"
+        backup_path = db_path.parent / backup_filename
+
+        logger.info("Backing up %s to %s", db_path, backup_path)
+        shutil.copy2(db_path, backup_path)
+
+        # Rotate backups
+        self._rotate_backups(db_path)
+
+    def _rotate_backups(self, db_path: Path, max_backups: int = 100) -> None:
+        """Rotate backups, keeping only the most recent ones.
+
+        Parameters
+        ----------
+        db_path : Path
+            Path to the original database file.
+        max_backups : int
+            Maximum number of backups to keep.
+        """
+        parent_dir = db_path.parent
+        stem = db_path.stem
+        suffix = db_path.suffix
+
+        # Pattern to match: {stem}.{digits}{suffix}.bk
+        # We need to escape special characters in stem and suffix for regex
+        escaped_stem = re.escape(stem)
+        escaped_suffix = re.escape(suffix)
+        pattern = re.compile(rf"^{escaped_stem}\.(\d+){escaped_suffix}\.bk$")
+
+        backups = []
+
+        # Scan directory for backups
+        try:
+            for file_path in parent_dir.iterdir():
+                if not file_path.is_file():
+                    continue
+
+                match = pattern.match(file_path.name)
+                if match:
+                    ts = int(match.group(1))
+                    backups.append((ts, file_path))
+        except OSError:
+            logger.warning("Failed to list backups in %s", parent_dir, exc_info=True)
+            return
+
+        # Sort by timestamp descending (newest first)
+        backups.sort(key=lambda x: x[0], reverse=True)
+
+        # Remove old backups
+        if len(backups) > max_backups:
+            to_remove = backups[max_backups:]
+            logger.info("Removing %d old backups for %s", len(to_remove), db_path.name)
+
+            for _, file_path in to_remove:
+                with suppress(OSError):
+                    file_path.unlink()

--- a/tests/services/tasks/test_metadata_db_backup_task.py
+++ b/tests/services/tasks/test_metadata_db_backup_task.py
@@ -1,0 +1,203 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for MetadataDbBackupTask."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlmodel import Session
+
+from bookcard.models.config import Library
+from bookcard.models.tasks import TaskType
+from bookcard.services.tasks.metadata_db_backup_task import MetadataDbBackupTask
+
+
+@pytest.fixture
+def mock_update_progress() -> MagicMock:
+    """Mock update_progress callback."""
+    return MagicMock()
+
+
+@pytest.fixture
+def backup_task(session: Session) -> MetadataDbBackupTask:
+    """Create a MetadataDbBackupTask instance."""
+    return MetadataDbBackupTask(
+        task_id=1,
+        user_id=1,
+        metadata={"task_type": TaskType.METADATA_BACKUP},
+    )
+
+
+def test_backup_single_library(
+    session: Session,
+    backup_task: MetadataDbBackupTask,
+    tmp_path: Path,
+    mock_update_progress: MagicMock,
+) -> None:
+    """Test backing up a single library."""
+    # Setup library with DB file
+    lib_dir = tmp_path / "library1"
+    lib_dir.mkdir()
+    db_file = lib_dir / "metadata.db"
+    db_file.write_text("dummy content")
+
+    library = Library(
+        name="Test Lib",
+        calibre_db_path=str(lib_dir),
+        calibre_db_file="metadata.db",
+    )
+    session.add(library)
+    session.commit()
+
+    # Configure exec result for library_repo.list()
+    session.add_exec_result([library])  # type: ignore[attr-defined]
+
+    # Run task
+    backup_task.update_progress = mock_update_progress  # type: ignore[method-assign]
+    backup_task.run({"session": session})
+
+    # Verify backup created
+    backups = list(lib_dir.glob("metadata.*.db.bk"))
+    assert len(backups) == 1
+    assert backups[0].read_text() == "dummy content"
+
+    # Verify progress update
+    mock_update_progress.assert_called_with(1.0)
+
+
+def test_backup_rotation(
+    session: Session,
+    backup_task: MetadataDbBackupTask,
+    tmp_path: Path,
+    mock_update_progress: MagicMock,
+) -> None:
+    """Test that old backups are rotated."""
+    # Setup library
+    lib_dir = tmp_path / "library_rotation"
+    lib_dir.mkdir()
+    db_file = lib_dir / "metadata.db"
+    db_file.write_text("current content")
+
+    library = Library(
+        name="Rotation Lib",
+        calibre_db_path=str(lib_dir),
+        calibre_db_file="metadata.db",
+    )
+    session.add(library)
+    session.commit()
+
+    # Configure exec result for library_repo.list()
+    session.add_exec_result([library])  # type: ignore[attr-defined]
+
+    # Create 105 fake old backups
+    for i in range(105):
+        # Use different timestamps
+        ts = 1000000000 + i
+        bk_file = lib_dir / f"metadata.{ts}.db.bk"
+        bk_file.write_text(f"backup {i}")
+
+    # Run task
+    backup_task.update_progress = mock_update_progress  # type: ignore[method-assign]
+    backup_task.run({"session": session})
+
+    # Verify rotation
+    # Should have 100 backups now (including the new one)
+    # Wait, the logic is: create new backup, then rotate.
+    # So if we had 105, we add 1 -> 106.
+    # Then we keep top 100.
+    # So we should have 100 files left.
+
+    backups = list(lib_dir.glob("metadata.*.db.bk"))
+    assert len(backups) == 100
+
+    # The newest backup should be present (the one we just created)
+    # It will have a much larger timestamp than our fake ones
+    # We can check content of the newest file
+    backups.sort(
+        key=lambda p: p.stat().st_mtime
+    )  # Modification time might be same if created fast
+    # Better sort by filename timestamp if possible, but regex extraction is needed.
+    # Let's just check that one file has "current content"
+
+    has_current = any(b.read_text() == "current content" for b in backups)
+    assert has_current
+
+
+def test_missing_db_file(
+    session: Session,
+    backup_task: MetadataDbBackupTask,
+    tmp_path: Path,
+    mock_update_progress: MagicMock,
+) -> None:
+    """Test handling of missing DB file."""
+    # Setup library pointing to non-existent file
+    lib_dir = tmp_path / "empty_lib"
+    lib_dir.mkdir()
+
+    library = Library(
+        name="Empty Lib",
+        calibre_db_path=str(lib_dir),
+        calibre_db_file="metadata.db",
+    )
+    session.add(library)
+    session.commit()
+
+    # Configure exec result for library_repo.list()
+    session.add_exec_result([library])  # type: ignore[attr-defined]
+
+    # Run task - should not raise exception
+    backup_task.update_progress = mock_update_progress  # type: ignore[method-assign]
+    backup_task.run({"session": session})
+
+    # Verify no backups created
+    backups = list(lib_dir.glob("*.bk"))
+    assert len(backups) == 0
+
+    # Progress still updated
+    mock_update_progress.assert_called_with(1.0)
+
+
+def test_custom_db_filename(
+    session: Session,
+    backup_task: MetadataDbBackupTask,
+    tmp_path: Path,
+    mock_update_progress: MagicMock,
+) -> None:
+    """Test backup with custom DB filename."""
+    lib_dir = tmp_path / "custom_lib"
+    lib_dir.mkdir()
+    db_file = lib_dir / "my_books.sqlite"
+    db_file.write_text("custom content")
+
+    library = Library(
+        name="Custom Lib",
+        calibre_db_path=str(lib_dir),
+        calibre_db_file="my_books.sqlite",
+    )
+    session.add(library)
+    session.commit()
+
+    # Configure exec result for library_repo.list()
+    session.add_exec_result([library])  # type: ignore[attr-defined]
+
+    backup_task.update_progress = mock_update_progress  # type: ignore[method-assign]
+    backup_task.run({"session": session})
+
+    # Check for backup: my_books.{ts}.sqlite.bk
+    backups = list(lib_dir.glob("my_books.*.sqlite.bk"))
+    assert len(backups) == 1
+    assert backups[0].read_text() == "custom content"


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Feature addition
  * [ ] Bug fix
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Adds a new scheduled job that automatically backs up metadata.db (or configured database file) for all configured libraries daily at 00:00 UTC, with automatic rotation to keep a maximum of 100 backups per library.

# Problem

Previously, there was no automated backup mechanism for library metadata databases. Users had to manually backup their Calibre metadata.db files, which could lead to data loss if backups were not performed regularly.

# Solution

- Implemented `MetadataDbBackupTask` that:
  - Finds all configured libraries (active or inactive)
  - Creates timestamped backups in the same directory as the database file
  - Uses naming scheme: `{stem}.{unix_timestamp}{suffix}.bk` (e.g., `metadata.1737763200.db.bk`)
  - Automatically rotates backups to keep maximum 100 copies per library
- Registered the task in the task factory
- Added Alembic migration to seed the scheduled job definition:
  - Job name: `metadata_backup_all_libraries`
  - Schedule: Daily at 00:00 UTC (`0 0 * * *`)
  - Enabled by default
- Added comprehensive unit tests covering backup creation, rotation, missing files, and custom database filenames

# Action

Additional actions required:
* [ ] Update documentation (if needed)
* [ ] Verify migration runs successfully in production
* [ ] Monitor first scheduled run to ensure backups are created correctly