### PR TITLE
Fix ConversionModal z-index and refactor for better maintainability

### DIFF
--- a/web/src/components/books/conversion/ConversionHistoryTable.tsx
+++ b/web/src/components/books/conversion/ConversionHistoryTable.tsx
@@ -1,0 +1,79 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { BookConversionListResponse } from "@/services/bookService";
+import { StatusBadge } from "./StatusBadge";
+
+export interface ConversionHistoryTableProps {
+  /** Conversion history response. */
+  history: BookConversionListResponse | undefined;
+}
+
+export function ConversionHistoryTable({
+  history,
+}: ConversionHistoryTableProps) {
+  if (!history?.items?.length) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6">
+      <h3 className="mb-2 font-semibold text-[var(--color-text-a0)] text-sm">
+        Conversion History
+      </h3>
+      <div className="max-h-[200px] overflow-y-auto rounded-md border border-[var(--color-surface-a20)]">
+        <table className="w-full text-sm">
+          <thead className="sticky top-0 bg-[var(--color-surface-a10)]">
+            <tr>
+              <th className="px-3 py-2 text-left text-[var(--color-text-a20)]">
+                From
+              </th>
+              <th className="px-3 py-2 text-left text-[var(--color-text-a20)]">
+                To
+              </th>
+              <th className="px-3 py-2 text-left text-[var(--color-text-a20)]">
+                Status
+              </th>
+              <th className="px-3 py-2 text-left text-[var(--color-text-a20)]">
+                Date
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.items.map((conv) => (
+              <tr
+                key={conv.id}
+                className="border-[var(--color-surface-a20)] border-t"
+              >
+                <td className="px-3 py-2 text-[var(--color-text-a0)]">
+                  {conv.original_format}
+                </td>
+                <td className="px-3 py-2 text-[var(--color-text-a0)]">
+                  {conv.target_format}
+                </td>
+                <td className="px-3 py-2">
+                  <StatusBadge status={conv.status} />
+                </td>
+                <td className="px-3 py-2 text-[var(--color-text-a20)] text-xs">
+                  {new Date(conv.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/books/conversion/StatusBadge.tsx
+++ b/web/src/components/books/conversion/StatusBadge.tsx
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { STATUS_BADGE_CLASS_BY_STATUS } from "@/constants/conversion";
+
+export interface StatusBadgeProps {
+  /** Human-readable status. */
+  status: string;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const normalizedStatus = status.trim().toLowerCase();
+  const className =
+    STATUS_BADGE_CLASS_BY_STATUS[normalizedStatus] ??
+    "bg-gray-500/20 text-gray-400";
+
+  return (
+    <span className={`inline-block rounded px-2 py-0.5 text-xs ${className}`}>
+      {status}
+    </span>
+  );
+}

--- a/web/src/constants/conversion.ts
+++ b/web/src/constants/conversion.ts
@@ -1,0 +1,31 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export const COMMON_TARGET_FORMATS = [
+  "EPUB",
+  "MOBI",
+  "AZW3",
+  "KEPUB",
+  "PDF",
+] as const;
+
+export const STATUS_BADGE_CLASS_BY_STATUS: Record<string, string> = {
+  completed: "bg-green-500/20 text-green-500",
+  failed: "bg-red-500/20 text-red-500",
+  error: "bg-red-500/20 text-red-500",
+  pending: "bg-yellow-500/20 text-yellow-500",
+  queued: "bg-yellow-500/20 text-yellow-500",
+  running: "bg-yellow-500/20 text-yellow-500",
+};

--- a/web/src/hooks/useBookConversion.ts
+++ b/web/src/hooks/useBookConversion.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useCallback } from "react";
+import { useGlobalMessages } from "@/contexts/GlobalMessageContext";
+import {
+  type BookConvertResponse,
+  convertBookFormat,
+} from "@/services/bookService";
+
+export interface UseBookConversionOptions {
+  /** Book ID to convert. */
+  bookId: number;
+  /** Callback fired once a conversion is queued. */
+  onConversionStarted?: (
+    taskId: number,
+    sourceFormat: string,
+    targetFormat: string,
+  ) => void;
+  /**
+   * Best-effort history refetch callback.
+   *
+   * Should resolve when refetch completes and reject on error.
+   */
+  refetchHistory: () => Promise<unknown>;
+}
+
+export interface UseBookConversionResult {
+  /** Queue a conversion (fire-and-forget). */
+  queueConversion: (sourceFormat: string, targetFormat: string) => void;
+}
+
+/**
+ * Queue a book format conversion and surface UX messaging.
+ *
+ * Parameters
+ * ----------
+ * options : UseBookConversionOptions
+ *     Hook configuration including book ID and callbacks.
+ *
+ * Returns
+ * -------
+ * UseBookConversionResult
+ *     A function for queueing conversions.
+ */
+export function useBookConversion(
+  options: UseBookConversionOptions,
+): UseBookConversionResult {
+  const { bookId, onConversionStarted, refetchHistory } = options;
+  const { showSuccess, showDanger } = useGlobalMessages();
+
+  const queueConversion = useCallback(
+    (sourceFormat: string, targetFormat: string) => {
+      convertBookFormat(bookId, sourceFormat, targetFormat)
+        .then((response: BookConvertResponse) => {
+          if (response.message) {
+            showSuccess(response.message);
+            return;
+          }
+
+          showSuccess(
+            `Conversion from ${sourceFormat} to ${targetFormat} has been queued. You can track progress in the tasks panel.`,
+          );
+          onConversionStarted?.(response.task_id, sourceFormat, targetFormat);
+        })
+        .then(() => {
+          // Refresh history in background (best-effort).
+          return refetchHistory().catch((error: unknown) => {
+            console.debug("Failed to refresh conversion history:", error);
+          });
+        })
+        .catch((error: unknown) => {
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : "Failed to queue conversion";
+          showDanger(errorMessage);
+        });
+    },
+    [bookId, onConversionStarted, refetchHistory, showDanger, showSuccess],
+  );
+
+  return { queueConversion };
+}

--- a/web/src/hooks/useConversionHistory.ts
+++ b/web/src/hooks/useConversionHistory.ts
@@ -1,0 +1,29 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  type BookConversionListResponse,
+  getBookConversions,
+} from "@/services/bookService";
+
+export function useConversionHistory(bookId: number, isOpen: boolean) {
+  return useQuery<BookConversionListResponse>({
+    queryKey: ["book-conversions", bookId],
+    queryFn: () => getBookConversions(bookId),
+    enabled: isOpen,
+    retry: false,
+  });
+}

--- a/web/src/hooks/useFormatSelection.ts
+++ b/web/src/hooks/useFormatSelection.ts
@@ -1,0 +1,113 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Book } from "@/types/book";
+import {
+  getAvailableFormats,
+  getTargetFormatOptions,
+} from "@/utils/conversion";
+
+export interface UseFormatSelectionResult {
+  /** Uppercased formats available on the book. */
+  availableFormats: string[];
+  /** Uppercased target formats the user can convert into. */
+  targetFormatOptions: string[];
+  /** Selected source format. */
+  sourceFormat: string;
+  /** Selected target format. */
+  targetFormat: string;
+  /** Set selected source format. */
+  setSourceFormat: (format: string) => void;
+  /** Set selected target format. */
+  setTargetFormat: (format: string) => void;
+}
+
+/**
+ * Manage conversion format selection for a book.
+ *
+ * Handles available/target format computation, default selections when the modal
+ * opens, and resets when switching to a different book.
+ *
+ * Parameters
+ * ----------
+ * book : Book
+ *     Book used to derive available formats.
+ * isOpen : boolean
+ *     Whether the modal is currently open.
+ *
+ * Returns
+ * -------
+ * UseFormatSelectionResult
+ *     Computed format options and selection state.
+ */
+export function useFormatSelection(
+  book: Book,
+  isOpen: boolean,
+): UseFormatSelectionResult {
+  const [sourceFormat, setSourceFormat] = useState<string>("");
+  const [targetFormat, setTargetFormat] = useState<string>("");
+
+  const previousBookIdRef = useRef<number | null>(null);
+  const previousIsOpenRef = useRef<boolean>(false);
+
+  const availableFormats = useMemo(() => getAvailableFormats(book), [book]);
+  const targetFormatOptions = useMemo(
+    () => getTargetFormatOptions(availableFormats),
+    [availableFormats],
+  );
+
+  // Reset format selection when opening for a different book.
+  useEffect(() => {
+    const previousBookId = previousBookIdRef.current;
+    const previousIsOpen = previousIsOpenRef.current;
+    const isOpening = isOpen && !previousIsOpen;
+    const bookChangedWhileOpen =
+      isOpen && previousBookId !== null && previousBookId !== book.id;
+
+    if (isOpening || bookChangedWhileOpen) {
+      setSourceFormat("");
+      setTargetFormat("");
+    }
+
+    previousBookIdRef.current = book.id;
+    previousIsOpenRef.current = isOpen;
+  }, [book.id, isOpen]);
+
+  // Set default source format when modal opens or formats reset.
+  useEffect(() => {
+    if (!isOpen || sourceFormat) {
+      return;
+    }
+    setSourceFormat(availableFormats[0] ?? "");
+  }, [isOpen, availableFormats, sourceFormat]);
+
+  // Set default target format when modal opens or formats reset.
+  useEffect(() => {
+    if (!isOpen || targetFormat) {
+      return;
+    }
+    setTargetFormat(targetFormatOptions[0] ?? "");
+  }, [isOpen, targetFormatOptions, targetFormat]);
+
+  return {
+    availableFormats,
+    targetFormatOptions,
+    sourceFormat,
+    targetFormat,
+    setSourceFormat,
+    setTargetFormat,
+  };
+}

--- a/web/src/types/conversion.ts
+++ b/web/src/types/conversion.ts
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+export type ConversionStartedCallback = (
+  taskId: number,
+  sourceFormat: string,
+  targetFormat: string,
+) => void;

--- a/web/src/utils/conversion.ts
+++ b/web/src/utils/conversion.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 knguyen and others
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { COMMON_TARGET_FORMATS } from "@/constants/conversion";
+import type { Book } from "@/types/book";
+
+export function normalizeFormat(format: string): string {
+  return format.trim().toUpperCase();
+}
+
+export function getAvailableFormats(book: Book): string[] {
+  return book.formats?.map((f) => normalizeFormat(f.format)) ?? [];
+}
+
+export function getTargetFormatOptions(availableFormats: string[]): string[] {
+  return COMMON_TARGET_FORMATS.filter(
+    (format) => !availableFormats.includes(format),
+  );
+}
+
+export function getConversionValidationError(
+  sourceFormat: string,
+  targetFormat: string,
+): string | null {
+  if (!sourceFormat || !targetFormat) {
+    return "Please select both source and target formats";
+  }
+  if (sourceFormat === targetFormat) {
+    return "Source and target formats must be different";
+  }
+  return null;
+}


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Fixes ConversionModal overlay z-index issue and refactors the component following SOLID principles by extracting logic into separate hooks, utils, constants, and subcomponents.

# Problem

1. **Z-index issue**: The ConversionModal overlay only covered a single row of BooksGrid instead of the entire page, because it used  instead of the higher z-index () used by other modals like ConfirmationModal.
2. **Code organization**: ConversionModal violated Single Responsibility Principle by mixing UI rendering, format selection logic, conversion history fetching, conversion submission, and modal behavior management in a single 442-line file.

# Solution

1. **Z-index fix**: 
   - Changed overlay from  to  (z-index: 1002)
   - Added portal rendering via  to ensure modal renders at document body level
   - Added  to prevent clicks inside modal from closing it

2. **Refactoring for maintainability**:
   - **Extracted hooks**: , , 
   - **Extracted utilities**: , , ,  → 
   - **Extracted constants**: ,  → 
   - **Extracted components**: ,  → 
   - **Extracted types**:  → 
   - **Reduced main component**: ConversionModal.tsx from 442 lines to ~313 lines, now focused primarily on UI composition

This refactoring improves:
- **Testability**: Business logic is now in pure functions and isolated hooks
- **Reusability**: Format utilities and status badge can be reused elsewhere
- **Maintainability**: Each file has a single, clear responsibility
- **Extensibility**: Status styling and target formats are now configuration-driven

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)