### PR TITLE
Fix flaky CBR page extraction by preferring bsdtar

### DIFF
--- a/bookcard/services/comic/archive/handlers/cbr.py
+++ b/bookcard/services/comic/archive/handlers/cbr.py
@@ -24,6 +24,7 @@ import rarfile
 from bookcard.services.comic.archive.exceptions import ArchiveReadError
 from bookcard.services.comic.archive.handlers.base import ArchiveHandler
 from bookcard.services.comic.archive.models import ArchiveMetadata, PageDetails
+from bookcard.services.comic.archive.rarfile_backend import prefer_bsdtar_on_linux
 from bookcard.services.comic.archive.utils import (
     is_image_entry,
     natural_sort_key,
@@ -70,6 +71,7 @@ class CBRHandler(ArchiveHandler):
         _ = metadata  # required by interface; unused for CBR
         validate_archive_entry_name(filename)
         try:
+            prefer_bsdtar_on_linux(rarfile)
             with rarfile.RarFile(file_path, "r") as rf:
                 return rf.read(filename)
         except (rarfile.Error, OSError, KeyError) as e:
@@ -87,6 +89,8 @@ class CBRHandler(ArchiveHandler):
         """Get per-page sizes and optional dimensions for a CBR."""
         details: dict[str, PageDetails] = {}
         try:
+            if include_dimensions:
+                prefer_bsdtar_on_linux(rarfile)
             with rarfile.RarFile(file_path, "r") as rf:
                 for name in metadata.page_filenames:
                     validate_archive_entry_name(name)

--- a/bookcard/services/comic/archive/rarfile_backend.py
+++ b/bookcard/services/comic/archive/rarfile_backend.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Helpers for configuring `rarfile` extraction backends.
+
+`rarfile` can use multiple external tools for extraction (unrar/unar/7z/bsdtar).
+In some environments (notably Linux + RAR5), `unar` may succeed partially and
+then EOF, causing `rarfile` to raise `BadRarFile` for an otherwise valid archive.
+
+We prefer `bsdtar` (libarchive) on Linux when available, as it has proven to be
+more reliable for the problematic CBRs we ingest.
+"""
+
+import shutil
+from types import ModuleType
+
+from bookcard.constants import IS_LINUX
+
+
+def prefer_bsdtar_on_linux(rarfile_module: ModuleType) -> None:
+    """Prefer `bsdtar` backend for `rarfile` extraction on Linux.
+
+    Parameters
+    ----------
+    rarfile_module : module
+        The imported `rarfile` module.
+
+    Notes
+    -----
+    `rarfile` selects a tool using a fixed preference order:
+
+    - `unrar` (if present)
+    - `unar`
+    - `7z` / `7zz`
+    - `bsdtar`
+
+    We have observed RAR5 CBRs where `unar` returns a truncated stream and
+    `7z` fails with "Unsupported Method", while `bsdtar -xf` succeeds.
+
+    This function forces `rarfile` to skip `unar`/`7z` and use `bsdtar` when
+    available. If `unrar` is present, it will still be preferred.
+    """
+    if not IS_LINUX:
+        return
+
+    # Only attempt this override when bsdtar exists on PATH.
+    if shutil.which("bsdtar") is None:
+        return
+
+    tool_setup = getattr(rarfile_module, "tool_setup", None)
+    if tool_setup is None:
+        return
+
+    # Prefer unrar if available; otherwise bsdtar. Avoid unar/7z which can fail
+    # on some RAR5 compression methods.
+    rar_cannot_exec = getattr(rarfile_module, "RarCannotExec", None)
+    expected_errors: tuple[type[BaseException], ...] = (OSError, ValueError, TypeError)
+    if isinstance(rar_cannot_exec, type) and issubclass(rar_cannot_exec, Exception):
+        expected_errors = (*expected_errors, rar_cannot_exec)
+    try:
+        tool_setup(
+            unrar=True,
+            unar=False,
+            bsdtar=True,
+            sevenzip=False,
+            sevenzip2=False,
+            force=True,
+        )
+    except expected_errors:
+        # If rarfile rejects the configuration for any reason, keep defaults.
+        # We intentionally do not fail extraction here; the actual read will
+        # surface a concrete error if no working tool exists.
+        return

--- a/bookcard/services/cover_extractors/cbz.py
+++ b/bookcard/services/cover_extractors/cbz.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from PIL import Image
 
+from bookcard.services.comic.archive.rarfile_backend import prefer_bsdtar_on_linux
 from bookcard.services.cover_extractors.base import CoverExtractionStrategy
 
 if TYPE_CHECKING:
@@ -138,6 +139,7 @@ class CbzCoverExtractor(CoverExtractionStrategy):
             return None
 
         try:
+            prefer_bsdtar_on_linux(rarfile)
             with rarfile.RarFile(file_path, "r") as cbr_rar:
                 # Find image files (sorted to get first page)
                 image_files = [

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -150,52 +150,11 @@ ENV PATH="/app/calibre:${PATH}"
 # Install uv for KCC
 RUN pip install --no-cache-dir uv
 
-ARG KCC_VERSION=v9.4.3
+ARG KCC_VERSION=master
 ENV KCC_VERSION=${KCC_VERSION}
 
 RUN git clone --depth 1 --branch ${KCC_VERSION} https://github.com/ciromattia/kcc.git /opt/kcc || \
     git clone --depth 1 https://github.com/ciromattia/kcc.git /opt/kcc
-
-# Patch KCC extraction on Linux:
-# Some CBR/RAR archives use compression methods that `7z` can list but cannot extract
-# (KCC then raises "Failed to extract archive"). `bsdtar` (libarchive) can extract these.
-# We inject `bsdtar` into KCC's extraction command list so it is tried first after the
-# existing `.reverse()` call.
-RUN python3 - <<'PY'
-from __future__ import annotations
-
-from pathlib import Path
-
-path = Path("/opt/kcc/kindlecomicconverter/comicarchive.py")
-text = path.read_text(encoding="utf-8")
-
-# Idempotency: skip if already patched.
-if "bsdtar" in text:
-    raise SystemExit(0)
-
-lines = text.splitlines()
-
-def _find_index(start: int, predicate) -> int:
-    for i in range(start, len(lines)):
-        if predicate(lines[i]):
-            return i
-    raise RuntimeError("Failed to locate patch insertion point in comicarchive.py")
-
-extract_def = _find_index(0, lambda l: l.startswith("    def extract(self, targetdir):"))
-list_start = _find_index(extract_def, lambda l: "extraction_commands = [" in l)
-list_end = _find_index(list_start + 1, lambda l: l.strip() == "]")
-
-# Insert as the last element in the list literal so that after `extraction_commands.reverse()`
-# it will be attempted first.
-bsdtar_cmd = (
-    "            ['bsdtar', '--exclude', '__MACOSX', '--exclude', '.DS_Store', "
-    "'--exclude', 'thumbs.db', '--exclude', 'Thumbs.db', '-xf', self.basename, "
-    "'-C', targetdir],"
-)
-lines.insert(list_end, bsdtar_cmd)
-
-path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-PY
 
 RUN uv venv /opt/kcc/venv && \
     . /opt/kcc/venv/bin/activate && \

--- a/tests/services/comic/test_comic_archive_archive_package.py
+++ b/tests/services/comic/test_comic_archive_archive_package.py
@@ -589,6 +589,8 @@ def test_cbr_handler_success_and_error_branches(
 
     import rarfile
 
+    monkeypatch.setattr(rarfile, "tool_setup", lambda *args, **kwargs: None)
+
     class FakeRarFile:
         def __init__(self, _path: Path, _mode: str) -> None:
             self._names = ["page2.png", "page1.jpg", "folder/"]


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [x] Other
* **Describe this change in 1-2 sentences**: Fix intermittent failures when reading specific pages from RAR5-based CBR files by forcing `rarfile` to prefer the `bsdtar` backend on Linux; also pin the bundled KCC clone to `master` to pick up upstream `bsdtar`-on-Linux extraction behavior.

# Problem

Some RAR5 CBRs (and/or specific entries within them) fail during page extraction with `rarfile.BadRarFile: Failed the read enough data (req=... got=524288)`. This is consistent with the selected backend tool producing a truncated stream (e.g. `unar` EOF mid-entry) or `7z` reporting "Unsupported Method".

# Solution

- Add `bookcard/services/comic/archive/rarfile_backend.py` with `prefer_bsdtar_on_linux()` and call it before reading CBR entries.
- Apply the same preference in `CbzCoverExtractor` for CBR cover extraction.
- Pin KCC clone to `master` in `infra/Dockerfile` (upstream now aliases `TAR=bsdtar` on Linux).

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)


Made with [Cursor](https://cursor.com)