### PR TITLE
fix: Make AuthorMetadataFetchTask library-aware via resolve_task_library + PinnedLibraryService

### DIFF
--- a/bookcard/services/tasks/author_metadata_fetch_task.py
+++ b/bookcard/services/tasks/author_metadata_fetch_task.py
@@ -27,8 +27,11 @@ from typing import TYPE_CHECKING, Any
 from bookcard.repositories.author_repository import AuthorRepository
 from bookcard.repositories.config_repository import LibraryRepository
 from bookcard.services.author_service import AuthorService
-from bookcard.services.config_service import LibraryService
 from bookcard.services.tasks.base import BaseTask
+from bookcard.services.tasks.task_library_resolver import (
+    PinnedLibraryService,
+    resolve_task_library,
+)
 
 if TYPE_CHECKING:
     from sqlmodel import Session
@@ -92,10 +95,12 @@ class AuthorMetadataFetchTask(BaseTask):
             # Update progress: 0.1 - starting
             update_progress(0.1, {"status": "initializing"})
 
-            # Create author service
+            # Resolve library via shared resolver (metadata → per-user → first available)
+            library = resolve_task_library(session, self.metadata, self.user_id)
+
             author_repo = AuthorRepository(session)
             library_repo = LibraryRepository(session)
-            library_service = LibraryService(session, library_repo)
+            library_service = PinnedLibraryService(session, library_repo, library)
             author_service = AuthorService(
                 session=session,
                 author_repo=author_repo,

--- a/bookcard/services/tasks/task_library_resolver.py
+++ b/bookcard/services/tasks/task_library_resolver.py
@@ -26,6 +26,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from bookcard.repositories.config_repository import LibraryRepository
+from bookcard.services.config_service import LibraryService
 from bookcard.services.tasks.exceptions import LibraryNotConfiguredError
 
 if TYPE_CHECKING:
@@ -109,3 +110,45 @@ def resolve_task_library(
         return library
 
     raise LibraryNotConfiguredError
+
+
+class PinnedLibraryService(LibraryService):
+    """``LibraryService`` that always returns a predetermined library.
+
+    Background tasks resolve the target library via
+    :func:`resolve_task_library` (metadata → per-user → first available).
+    Service layers like ``AuthorService`` expect a ``LibraryService``
+    whose ``get_active_library()`` they call internally.  This adapter
+    bridges the two: the task resolves the library once, then injects a
+    ``PinnedLibraryService`` so every downstream ``get_active_library()``
+    call returns the correct library.
+
+    Parameters
+    ----------
+    session : Session
+        Active database session.
+    library_repo : LibraryRepository
+        Library repository (passed through to the base class so methods
+        like ``get_library`` and ``list_libraries`` still work).
+    library : Library
+        The pre-resolved library to pin.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        library_repo: LibraryRepository,
+        library: Library,
+    ) -> None:
+        super().__init__(session, library_repo)
+        self._pinned = library
+
+    def get_active_library(self) -> Library | None:
+        """Return the pinned library.
+
+        Returns
+        -------
+        Library | None
+            Always the library supplied at construction time.
+        """
+        return self._pinned

--- a/tests/services/tasks/test_author_metadata_fetch_task.py
+++ b/tests/services/tasks/test_author_metadata_fetch_task.py
@@ -21,9 +21,25 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from bookcard.models.config import Library
 from bookcard.services.tasks.author_metadata_fetch_task import (
     AuthorMetadataFetchTask,
 )
+from bookcard.services.tasks.exceptions import LibraryNotConfiguredError
+
+
+@pytest.fixture
+def library() -> Library:
+    """Return a test Library instance.
+
+    Returns
+    -------
+    Library
+        Library with id=1.
+    """
+    lib = Library(name="Test Library", path="/tmp/test-library", is_active=True)
+    lib.id = 1
+    return lib
 
 
 @pytest.fixture
@@ -77,27 +93,32 @@ class TestAuthorMetadataFetchTaskInit:
 class TestAuthorMetadataFetchTaskRun:
     """Test AuthorMetadataFetchTask run method."""
 
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryService")
     @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
     def test_run_success(
         self,
+        mock_resolve: MagicMock,
         mock_author_service_class: MagicMock,
-        mock_library_service_class: MagicMock,
-        mock_library_repo_class: MagicMock,
-        mock_author_repo_class: MagicMock,
         worker_context: dict[str, MagicMock],
         metadata: dict[str, str],
+        library: Library,
     ) -> None:
-        """Test run successfully fetches author metadata."""
-        # Setup mocks
-        mock_author_repo = MagicMock()
-        mock_author_repo_class.return_value = mock_author_repo
-        mock_library_repo = MagicMock()
-        mock_library_repo_class.return_value = mock_library_repo
-        mock_library_service = MagicMock()
-        mock_library_service_class.return_value = mock_library_service
+        """Test run successfully fetches author metadata.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        mock_author_service_class : MagicMock
+            Mock for AuthorService class.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        library : Library
+            Test library.
+        """
+        mock_resolve.return_value = library
         mock_author_service = MagicMock()
         mock_author_service.fetch_author_metadata.return_value = {
             "message": "Success",
@@ -105,76 +126,70 @@ class TestAuthorMetadataFetchTaskRun:
         }
         mock_author_service_class.return_value = mock_author_service
 
-        task = AuthorMetadataFetchTask(
-            task_id=1,
-            user_id=1,
-            metadata=metadata,
-        )
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
 
         task.run(worker_context)
 
-        # Verify progress updates
+        mock_resolve.assert_called_once_with(worker_context["session"], metadata, 1)
         assert worker_context["update_progress"].call_count >= 3
-        # Verify author service was called
         mock_author_service.fetch_author_metadata.assert_called_once_with("OL123A")
 
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryService")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
     def test_run_cancelled_before_processing(
         self,
-        mock_author_service_class: MagicMock,
-        mock_library_service_class: MagicMock,
-        mock_library_repo_class: MagicMock,
-        mock_author_repo_class: MagicMock,
+        mock_resolve: MagicMock,
         worker_context: dict[str, MagicMock],
         metadata: dict[str, str],
     ) -> None:
-        """Test run returns early when cancelled before processing."""
-        task = AuthorMetadataFetchTask(
-            task_id=1,
-            user_id=1,
-            metadata=metadata,
-        )
+        """Test run returns early when cancelled before processing.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        """
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
         task.mark_cancelled()
 
         task.run(worker_context)
 
-        # Should not call author service
-        mock_author_service_class.assert_not_called()
+        mock_resolve.assert_not_called()
 
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryService")
     @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
     def test_run_cancelled_during_execution(
         self,
+        mock_resolve: MagicMock,
         mock_author_service_class: MagicMock,
-        mock_library_service_class: MagicMock,
-        mock_library_repo_class: MagicMock,
-        mock_author_repo_class: MagicMock,
         worker_context: dict[str, MagicMock],
         metadata: dict[str, str],
+        library: Library,
     ) -> None:
-        """Test run returns early when cancelled during execution."""
-        # Setup mocks
-        mock_author_repo = MagicMock()
-        mock_author_repo_class.return_value = mock_author_repo
-        mock_library_repo = MagicMock()
-        mock_library_repo_class.return_value = mock_library_repo
-        mock_library_service = MagicMock()
-        mock_library_service_class.return_value = mock_library_service
+        """Test run returns early when cancelled during execution.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        mock_author_service_class : MagicMock
+            Mock for AuthorService class.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        library : Library
+            Test library.
+        """
+        mock_resolve.return_value = library
         mock_author_service = MagicMock()
         mock_author_service_class.return_value = mock_author_service
 
-        task = AuthorMetadataFetchTask(
-            task_id=1,
-            user_id=1,
-            metadata=metadata,
-        )
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
 
-        # Mark as cancelled after first progress update
         def cancel_after_first(*args: object, **kwargs: object) -> None:
             task.mark_cancelled()
 
@@ -182,39 +197,145 @@ class TestAuthorMetadataFetchTaskRun:
 
         task.run(worker_context)
 
-        # Should not call fetch_author_metadata
         mock_author_service.fetch_author_metadata.assert_not_called()
 
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryRepository")
-    @patch("bookcard.services.tasks.author_metadata_fetch_task.LibraryService")
     @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
     def test_run_exception(
         self,
+        mock_resolve: MagicMock,
         mock_author_service_class: MagicMock,
-        mock_library_service_class: MagicMock,
-        mock_library_repo_class: MagicMock,
-        mock_author_repo_class: MagicMock,
         worker_context: dict[str, MagicMock],
         metadata: dict[str, str],
+        library: Library,
     ) -> None:
-        """Test run raises exception on error."""
-        # Setup mocks
-        mock_author_repo = MagicMock()
-        mock_author_repo_class.return_value = mock_author_repo
-        mock_library_repo = MagicMock()
-        mock_library_repo_class.return_value = mock_library_repo
-        mock_library_service = MagicMock()
-        mock_library_service_class.return_value = mock_library_service
+        """Test run raises exception on error.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        mock_author_service_class : MagicMock
+            Mock for AuthorService class.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        library : Library
+            Test library.
+        """
+        mock_resolve.return_value = library
         mock_author_service = MagicMock()
         mock_author_service.fetch_author_metadata.side_effect = ValueError("Test error")
         mock_author_service_class.return_value = mock_author_service
 
-        task = AuthorMetadataFetchTask(
-            task_id=1,
-            user_id=1,
-            metadata=metadata,
-        )
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
 
         with pytest.raises(ValueError, match="Test error"):
             task.run(worker_context)
+
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
+    def test_run_library_not_configured(
+        self,
+        mock_resolve: MagicMock,
+        worker_context: dict[str, MagicMock],
+        metadata: dict[str, str],
+    ) -> None:
+        """Test run raises LibraryNotConfiguredError when no library found.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        """
+        mock_resolve.side_effect = LibraryNotConfiguredError()
+
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
+
+        with pytest.raises(LibraryNotConfiguredError):
+            task.run(worker_context)
+
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
+    def test_run_uses_library_id_from_metadata(
+        self,
+        mock_resolve: MagicMock,
+        mock_author_service_class: MagicMock,
+        worker_context: dict[str, MagicMock],
+        library: Library,
+    ) -> None:
+        """Test that library_id from metadata is forwarded to the resolver.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        mock_author_service_class : MagicMock
+            Mock for AuthorService class.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        library : Library
+            Test library.
+        """
+        metadata = {"author_id": "OL456A", "library_id": 42}
+        mock_resolve.return_value = library
+        mock_author_service = MagicMock()
+        mock_author_service.fetch_author_metadata.return_value = {"message": "OK"}
+        mock_author_service_class.return_value = mock_author_service
+
+        task = AuthorMetadataFetchTask(task_id=1, user_id=7, metadata=metadata)
+
+        task.run(worker_context)
+
+        mock_resolve.assert_called_once_with(worker_context["session"], metadata, 7)
+
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.AuthorService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.PinnedLibraryService")
+    @patch("bookcard.services.tasks.author_metadata_fetch_task.resolve_task_library")
+    def test_run_injects_pinned_library_service(
+        self,
+        mock_resolve: MagicMock,
+        mock_pinned_class: MagicMock,
+        mock_author_service_class: MagicMock,
+        worker_context: dict[str, MagicMock],
+        metadata: dict[str, str],
+        library: Library,
+    ) -> None:
+        """Test that AuthorService receives a PinnedLibraryService.
+
+        Parameters
+        ----------
+        mock_resolve : MagicMock
+            Mock for resolve_task_library.
+        mock_pinned_class : MagicMock
+            Mock for PinnedLibraryService class.
+        mock_author_service_class : MagicMock
+            Mock for AuthorService class.
+        worker_context : dict[str, MagicMock]
+            Mock worker context.
+        metadata : dict[str, str]
+            Task metadata.
+        library : Library
+            Test library.
+        """
+        mock_resolve.return_value = library
+        mock_pinned_instance = MagicMock()
+        mock_pinned_class.return_value = mock_pinned_instance
+        mock_author_service = MagicMock()
+        mock_author_service.fetch_author_metadata.return_value = {"message": "OK"}
+        mock_author_service_class.return_value = mock_author_service
+
+        task = AuthorMetadataFetchTask(task_id=1, user_id=1, metadata=metadata)
+
+        task.run(worker_context)
+
+        mock_pinned_class.assert_called_once()
+        call_kwargs = mock_pinned_class.call_args
+        assert call_kwargs[0][2] is library  # third positional arg = library
+        mock_author_service_class.assert_called_once()
+        svc_kwargs = mock_author_service_class.call_args[1]
+        assert svc_kwargs["library_service"] is mock_pinned_instance

--- a/tests/services/tasks/test_task_library_resolver.py
+++ b/tests/services/tasks/test_task_library_resolver.py
@@ -23,7 +23,10 @@ from sqlmodel import Session
 
 from bookcard.models.config import Library
 from bookcard.services.tasks.exceptions import LibraryNotConfiguredError
-from bookcard.services.tasks.task_library_resolver import resolve_task_library
+from bookcard.services.tasks.task_library_resolver import (
+    PinnedLibraryService,
+    resolve_task_library,
+)
 from tests.conftest import DummySession
 
 
@@ -451,3 +454,49 @@ class TestResolutionPriority:
 
             mock_repo.get.assert_not_called()
             assert result is library
+
+
+class TestPinnedLibraryService:
+    """Tests for PinnedLibraryService."""
+
+    def test_get_active_library_returns_pinned(
+        self,
+        session: Session,
+        library: Library,
+    ) -> None:
+        """get_active_library always returns the pinned library.
+
+        Parameters
+        ----------
+        session : Session
+            Mock session.
+        library : Library
+            Library to pin.
+        """
+        mock_repo = MagicMock()
+        svc = PinnedLibraryService(session, mock_repo, library)
+        assert svc.get_active_library() is library
+
+    def test_get_active_library_ignores_repo_contents(
+        self,
+        session: Session,
+        library: Library,
+        library_b: Library,
+    ) -> None:
+        """Pinned service ignores what the repo would return.
+
+        Parameters
+        ----------
+        session : Session
+            Mock session.
+        library : Library
+            Library to pin.
+        library_b : Library
+            A different library in the repo.
+        """
+        mock_repo = MagicMock()
+        mock_repo.list_all.return_value = [library_b]
+
+        svc = PinnedLibraryService(session, mock_repo, library)
+        assert svc.get_active_library() is library
+        assert svc.get_active_library() is not library_b


### PR DESCRIPTION
# Summary

* This is a…
  * [ ] Bug fix
  * [ ] Feature addition
  * [x] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Makes `AuthorMetadataFetchTask` library-aware by resolving the library through `resolve_task_library()` and injecting a `PinnedLibraryService` into `AuthorService`, so all downstream sub-services (`AuthorCoreService`, `AuthorMetadataService`, `AuthorPhotoService`) respect the task's `library_id` metadata and per-user active library.

# Problem

`AuthorMetadataFetchTask` constructed a plain `LibraryService` which always returned the first library via `get_active_library()`. This ignored the `library_id` captured in task metadata and the per-user active library, breaking multi-library setups where a user's author metadata fetch should target a specific library.

# Solution

- **`PinnedLibraryService`** — new `LibraryService` subclass in `task_library_resolver.py` that overrides `get_active_library()` to always return a pre-resolved library. Bridges the task-level resolver with service layers that depend on `LibraryService`.
- **`author_metadata_fetch_task.py`** — replaced raw `LibraryService` construction with `resolve_task_library(session, self.metadata, self.user_id)` + `PinnedLibraryService`, following the same pattern used by all other library-aware tasks.
- **Tests** — replaced `LibraryRepository`/`LibraryService` mocks with `resolve_task_library` mocks. Added new tests for `LibraryNotConfiguredError` propagation, metadata `library_id` forwarding, and `PinnedLibraryService` injection verification.

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)

Made with [Cursor](https://cursor.com)