### PR TITLE
fix: enforce max duration for scheduled tasks

### DIFF
--- a/bookcard/services/scheduler/service.py
+++ b/bookcard/services/scheduler/service.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import Engine
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
@@ -32,6 +33,8 @@ from sqlmodel import Session, select
 from bookcard.models.auth import User
 from bookcard.models.config import ScheduledJobDefinition, ScheduledTasksConfig
 from bookcard.models.tasks import TaskType
+from bookcard.services.task_service import TaskService
+from bookcard.services.tasks.stale_task_reaper import StaleTaskReaper
 
 if TYPE_CHECKING:
     from bookcard.services.tasks.base import TaskRunner
@@ -62,6 +65,7 @@ class APSchedulerService:
         """
         self._engine = engine
         self._task_runner = task_runner
+        self._stale_task_reaper = StaleTaskReaper(engine, task_runner)
 
         # Configure APScheduler
         # We use MemoryJobStore for now since our jobs are dynamic based on config
@@ -83,8 +87,27 @@ class APSchedulerService:
             self._scheduler.start()
             logger.info("APScheduler started")
 
+        self._register_stale_task_reaper()
+
         # Initial job registration
         self.refresh_jobs()
+
+    def _register_stale_task_reaper(self) -> None:
+        """Register the stale task reaper as a periodic internal job."""
+        self._scheduler.add_job(
+            func=self._stale_task_reaper.reap,
+            trigger=IntervalTrigger(minutes=5),
+            id="_internal_stale_task_reaper",
+            replace_existing=True,
+            name="Internal: stale task reaper",
+        )
+        logger.info("Stale task reaper registered (every 5 min)")
+
+    def _remove_user_jobs(self) -> None:
+        """Remove all user-defined jobs while preserving internal ones."""
+        for job in self._scheduler.get_jobs():
+            if not job.id.startswith("_internal_"):
+                job.remove()
 
     def shutdown(self) -> None:
         """Shutdown the scheduler."""
@@ -95,8 +118,9 @@ class APSchedulerService:
     def refresh_jobs(self) -> None:
         """Refresh scheduled jobs based on current database configuration.
 
-        Removes all existing jobs and re-registers them based on the latest config.
-        This allows changing schedules without restarting the application.
+        Removes all user-defined jobs and re-registers them based on the
+        latest config.  Internal jobs (prefixed with ``_internal_``) are
+        preserved across refreshes.
         """
         try:
             with Session(self._engine) as session:
@@ -107,8 +131,7 @@ class APSchedulerService:
 
                 if not jobs:
                     logger.warning("No enabled scheduled jobs found")
-                    # We still clear existing jobs as the user might have disabled everything
-                    self._scheduler.remove_all_jobs()
+                    self._remove_user_jobs()
                     return
 
                 system_user = self._get_system_user(session)
@@ -116,8 +139,7 @@ class APSchedulerService:
                     logger.warning("No system user found, skipping job registration")
                     return
 
-                # Clear existing jobs only if we proceed with registration
-                self._scheduler.remove_all_jobs()
+                self._remove_user_jobs()
 
                 for job in jobs:
                     user_id = job.user_id if job.user_id is not None else system_user.id
@@ -212,6 +234,14 @@ class APSchedulerService:
     ) -> None:
         """Execute task callback (runs in scheduler thread pool)."""
         try:
+            if self._has_active_task_of_type(task_type):
+                logger.warning(
+                    "Skipping scheduled %s — an active task of this type "
+                    "already exists (PENDING or RUNNING)",
+                    task_type.value,
+                )
+                return
+
             effective_metadata = metadata.copy()
             max_runtime_seconds = self._get_scheduled_task_max_runtime_seconds()
             if max_runtime_seconds is not None:
@@ -226,6 +256,28 @@ class APSchedulerService:
             logger.info("Scheduled task %s triggered (id=%s)", task_type.value, task_id)
         except Exception:
             logger.exception("Failed to trigger scheduled task %s", task_type.value)
+
+    def _has_active_task_of_type(self, task_type: TaskType) -> bool:
+        """Check if a PENDING or RUNNING task of the given type already exists.
+
+        Parameters
+        ----------
+        task_type : TaskType
+            Task type to check.
+
+        Returns
+        -------
+        bool
+            True if an active task of this type exists.
+        """
+        try:
+            with Session(self._engine) as session:
+                return TaskService(session).has_active_task_of_type(task_type)
+        except SQLAlchemyError:
+            logger.exception(
+                "Failed to check for active tasks of type %s", task_type.value
+            )
+            return False
 
     def _get_scheduled_task_max_runtime_seconds(self) -> int | None:
         """Get the max runtime (seconds) for scheduled tasks from system config.

--- a/bookcard/services/task_service.py
+++ b/bookcard/services/task_service.py
@@ -22,7 +22,7 @@ Follows SRP by handling only task persistence and retrieval.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import desc, func, select, update
@@ -385,6 +385,52 @@ class TaskService:
         self._session.add(task)
         self._session.commit()
         return True
+
+    def has_active_task_of_type(self, task_type: TaskType) -> bool:
+        """Check whether a PENDING or RUNNING task of the given type exists.
+
+        Parameters
+        ----------
+        task_type : TaskType
+            Task type to check.
+
+        Returns
+        -------
+        bool
+            True if at least one active (PENDING/RUNNING) task of this type exists.
+        """
+        active_statuses = [TaskStatus.PENDING, TaskStatus.RUNNING]
+        stmt = (
+            select(func.count())
+            .select_from(Task)
+            .where(
+                Task.task_type == task_type,
+                Task.status.in_(active_statuses),  # type: ignore[union-attr]
+            )
+        )
+        return self._session.exec(stmt).one() > 0
+
+    def find_stale_running_tasks(self, max_age_seconds: int) -> Sequence[Task]:
+        """Find RUNNING tasks whose elapsed time exceeds the given threshold.
+
+        Parameters
+        ----------
+        max_age_seconds : int
+            Maximum allowed runtime in seconds. Tasks running longer than
+            this are considered stale.
+
+        Returns
+        -------
+        Sequence[Task]
+            Tasks that have been running longer than ``max_age_seconds``.
+        """
+        cutoff = datetime.now(UTC) - timedelta(seconds=max_age_seconds)
+        stmt = select(Task).where(
+            Task.status == TaskStatus.RUNNING,  # type: ignore[invalid-argument-type]
+            Task.started_at.isnot(None),  # type: ignore[union-attr]
+            Task.started_at <= cutoff,  # type: ignore[operator]
+        )
+        return list(self._session.exec(stmt).all())  # type: ignore[call-overload]
 
     def count_tasks(
         self,

--- a/bookcard/services/tasks/stale_task_reaper.py
+++ b/bookcard/services/tasks/stale_task_reaper.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Stale task reaper service.
+
+Periodically detects RUNNING tasks that have exceeded their maximum allowed
+runtime and marks them as FAILED.  This acts as a safety net when cooperative
+cancellation (``mark_cancelled`` / ``check_cancelled``) is insufficient —
+e.g. when a task is blocked on I/O and never polls its cancellation flag.
+
+Follows SRP: sole responsibility is detecting and cleaning up stale tasks.
+Follows IOC: accepts Engine and TaskRunner as constructor dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlmodel import Session, select
+
+from bookcard.models.config import ScheduledTasksConfig
+from bookcard.services.task_service import TaskService
+
+if TYPE_CHECKING:
+    from sqlalchemy import Engine
+
+    from bookcard.services.tasks.base import TaskRunner
+
+logger = logging.getLogger(__name__)
+
+_REAPER_ERROR_TEMPLATE = (
+    "Task exceeded maximum runtime of {hours}h (reaped by watchdog)"
+)
+
+
+class StaleTaskReaper:
+    """Detects and fails tasks that have exceeded their maximum runtime.
+
+    Intended to be called periodically (e.g. every 5 minutes) via the
+    application scheduler.
+
+    Parameters
+    ----------
+    engine : Engine
+        SQLAlchemy engine for database access.
+    task_runner : TaskRunner
+        Task runner instance for cooperative cancellation signals.
+    """
+
+    def __init__(self, engine: Engine, task_runner: TaskRunner) -> None:
+        self._engine = engine
+        self._task_runner = task_runner
+
+    def reap(self) -> int:
+        """Scan for stale running tasks and mark them as failed.
+
+        Returns
+        -------
+        int
+            Number of tasks that were reaped.
+        """
+        max_runtime_seconds = self._get_max_runtime_seconds()
+        if max_runtime_seconds is None:
+            return 0
+
+        try:
+            with Session(self._engine) as session:
+                task_service = TaskService(session)
+                stale_tasks = task_service.find_stale_running_tasks(max_runtime_seconds)
+
+                if not stale_tasks:
+                    return 0
+
+                duration_hours = max_runtime_seconds / 3600
+                error_message = _REAPER_ERROR_TEMPLATE.format(
+                    hours=f"{duration_hours:g}"
+                )
+
+                reaped = 0
+                for task in stale_tasks:
+                    task_id = task.id
+                    if task_id is None:
+                        continue
+
+                    logger.warning(
+                        "Reaping stale task %s (%s) — running since %s",
+                        task_id,
+                        task.task_type,
+                        task.started_at,
+                    )
+
+                    with suppress(SQLAlchemyError):
+                        self._task_runner.cancel(task_id)
+
+                    task_service.fail_task(task_id, error_message)
+                    reaped += 1
+
+                if reaped:
+                    logger.warning("Stale task reaper cleaned up %d task(s)", reaped)
+                return reaped
+
+        except SQLAlchemyError:
+            logger.exception("Stale task reaper failed during scan")
+            return 0
+
+    def _get_max_runtime_seconds(self) -> int | None:
+        """Read the configured max runtime from ``ScheduledTasksConfig``.
+
+        Returns
+        -------
+        int | None
+            Maximum runtime in seconds, or None if unavailable.
+        """
+        try:
+            with Session(self._engine) as session:
+                config = session.exec(select(ScheduledTasksConfig).limit(1)).first()
+        except SQLAlchemyError:
+            logger.exception("Stale task reaper: failed to read ScheduledTasksConfig")
+            return None
+
+        if config is None:
+            return None
+
+        try:
+            duration_hours = int(config.duration_hours)
+        except (TypeError, ValueError):
+            logger.exception("Stale task reaper: invalid duration_hours value")
+            return None
+
+        if duration_hours <= 0:
+            return None
+        return duration_hours * 3600

--- a/bookcard/services/tasks/task_executor.py
+++ b/bookcard/services/tasks/task_executor.py
@@ -81,10 +81,14 @@ class TaskExecutor:
             task_instance.run(worker_context)
             duration = time.time() - start_time
 
-            # Check if task was cancelled
+            # Check if task was cancelled or already failed (e.g. by timeout reaper)
             task = self._task_service.get_task(task_id)
-            if task and task.status == TaskStatus.CANCELLED:
-                logger.info("Task %s was cancelled", task_id)
+            if task and task.is_complete:
+                logger.info(
+                    "Task %s already in terminal state (%s); skipping completion",
+                    task_id,
+                    task.status,
+                )
                 return
 
             # Task completed successfully - normalize and save metadata
@@ -127,8 +131,7 @@ class TaskExecutor:
                     session.rollback()
                 task = self._task_service.get_task(task_id)
 
-            if not task or task.status != TaskStatus.FAILED:
-                # Only fail if not already failed
+            if not task or not task.is_complete:
                 self._task_service.fail_task(task_id, error_message)
 
             # Record task completion - wrap in try/except to prevent

--- a/bookcard/services/tasks/thread_runner/runner.py
+++ b/bookcard/services/tasks/thread_runner/runner.py
@@ -246,7 +246,11 @@ class ThreadTaskRunner(TaskRunner):
         return None
 
     def _cancel_for_timeout(self, task_id: int, timeout_seconds: float) -> None:
-        """Cancel a task that exceeded its allowed runtime.
+        """Fail a task that exceeded its allowed runtime.
+
+        Sends a cooperative cancellation signal (``mark_cancelled``) so the
+        task can exit its work loop, then marks the task as FAILED in the
+        database with a descriptive timeout error message.
 
         Parameters
         ----------
@@ -255,15 +259,28 @@ class ThreadTaskRunner(TaskRunner):
         timeout_seconds : float
             Timeout threshold (seconds) that was exceeded.
         """
+        hours = timeout_seconds / 3600
+        error_message = f"Task exceeded maximum runtime of {hours:g}h"
         logger.warning(
-            "Task %s exceeded max runtime (%.0fs); sending cancellation signal",
+            "Task %s exceeded max runtime (%.0fs); marking as failed",
             task_id,
             timeout_seconds,
         )
         try:
-            self.cancel(task_id)
+            # Cooperative signal so the task can exit its work loop
+            with self._lock:
+                task_instance = self._running_tasks.get(task_id)
+                if task_instance is not None:
+                    task_instance.mark_cancelled()
+
+            # Mark as FAILED (not CANCELLED) — this is a system timeout
+            with self._context_builder.build_service_context() as (
+                _,
+                task_service,
+            ):
+                task_service.fail_task(task_id, error_message)
         except SQLAlchemyError:
-            logger.exception("Database error cancelling task %s after timeout", task_id)
+            logger.exception("Database error failing task %s after timeout", task_id)
 
     def enqueue(
         self,

--- a/tests/services/scheduler/test_service.py
+++ b/tests/services/scheduler/test_service.py
@@ -102,12 +102,19 @@ class TestAPSchedulerService:
             mock_session.exec.return_value = mock_jobs_result
 
             mock_scheduler = cast("MagicMock", service._scheduler)
-            mock_scheduler.remove_all_jobs.reset_mock()
+
+            # Set up user jobs to be removed (internal jobs are preserved)
+            user_job = MagicMock()
+            user_job.id = "pvr_download_monitor"
+            internal_job = MagicMock()
+            internal_job.id = "_internal_stale_task_reaper"
+            mock_scheduler.get_jobs.return_value = [user_job, internal_job]
 
             service.refresh_jobs()
 
-            # Verify remove_all_jobs was called to clear any existing jobs
-            mock_scheduler.remove_all_jobs.assert_called_once()
+            # Verify user jobs were removed but internal jobs preserved
+            user_job.remove.assert_called_once()
+            internal_job.remove.assert_not_called()
 
             # Verify no jobs were added (add_job not called)
             mock_scheduler.add_job.assert_not_called()
@@ -192,11 +199,17 @@ class TestAPSchedulerService:
             # Sequence: jobs, user
             mock_session.exec.side_effect = [mock_jobs_result, mock_user_result]
 
+            mock_scheduler = cast("MagicMock", service._scheduler)
+
+            # Set up existing user job to be cleared
+            old_job = MagicMock()
+            old_job.id = "old_job"
+            mock_scheduler.get_jobs.return_value = [old_job]
+
             service.refresh_jobs()
 
-            # Should clear existing jobs
-            mock_scheduler = cast("MagicMock", service._scheduler)
-            mock_scheduler.remove_all_jobs.assert_called_once()
+            # Should clear existing user jobs
+            old_job.remove.assert_called_once()
 
             # Should add 2 jobs
             assert mock_scheduler.add_job.call_count == 2
@@ -248,6 +261,9 @@ class TestAPSchedulerService:
 
             mock_session.exec.side_effect = [mock_jobs_result, mock_user_result]
 
+            mock_scheduler = cast("MagicMock", service._scheduler)
+            mock_scheduler.get_jobs.return_value = []
+
             # Mock CronTrigger to raise ValueError
             with patch(
                 "bookcard.services.scheduler.service.CronTrigger.from_crontab",
@@ -255,9 +271,7 @@ class TestAPSchedulerService:
             ):
                 service.refresh_jobs()
 
-                # Should clear jobs but not add any if cron fails
-                mock_scheduler = cast("MagicMock", service._scheduler)
-                mock_scheduler.remove_all_jobs.assert_called_once()
+                # Should not add any jobs if cron fails
                 mock_scheduler.add_job.assert_not_called()
 
     def test_execute_task(
@@ -271,7 +285,8 @@ class TestAPSchedulerService:
         user_id = 1
         metadata = {"meta": "data"}
 
-        service._execute_task(task_type, payload, user_id, metadata)
+        with patch.object(service, "_has_active_task_of_type", return_value=False):
+            service._execute_task(task_type, payload, user_id, metadata)
 
         # The scheduler may augment metadata with runtime limits derived from
         # ScheduledTasksConfig.duration_hours. Ensure we preserve original metadata
@@ -287,6 +302,22 @@ class TestAPSchedulerService:
         assert isinstance(kwargs["metadata"].get("max_runtime_seconds"), int)
         assert kwargs["metadata"]["max_runtime_seconds"] > 0
 
+    def test_execute_task_skipped_when_active(
+        self,
+        service: APSchedulerService,
+        mock_task_runner: MagicMock,
+    ) -> None:
+        """Test task execution is skipped when an active task already exists."""
+        with patch.object(service, "_has_active_task_of_type", return_value=True):
+            service._execute_task(
+                TaskType.PVR_DOWNLOAD_MONITOR,
+                {},
+                1,
+                {},
+            )
+
+        mock_task_runner.enqueue.assert_not_called()
+
     def test_execute_task_error(
         self,
         service: APSchedulerService,
@@ -296,9 +327,236 @@ class TestAPSchedulerService:
         mock_task_runner.enqueue.side_effect = RuntimeError("Enqueue failed")
 
         # Should not raise exception
-        service._execute_task(
-            TaskType.PVR_DOWNLOAD_MONITOR,
-            {},
-            1,
-            {},
-        )
+        with patch.object(service, "_has_active_task_of_type", return_value=False):
+            service._execute_task(
+                TaskType.PVR_DOWNLOAD_MONITOR,
+                {},
+                1,
+                {},
+            )
+
+
+class TestStaleTaskReaperRegistration:
+    """Tests for stale task reaper registration in the scheduler."""
+
+    @pytest.fixture
+    def mock_engine(self) -> MagicMock:
+        """Mock SQLAlchemy engine."""
+        return MagicMock(spec=Engine)
+
+    @pytest.fixture
+    def mock_task_runner(self) -> MagicMock:
+        """Mock task runner."""
+        return MagicMock(spec=TaskRunner)
+
+    @pytest.fixture
+    def service(
+        self, mock_engine: MagicMock, mock_task_runner: MagicMock
+    ) -> APSchedulerService:
+        """Create service instance with mocks."""
+        with patch("bookcard.services.scheduler.service.BackgroundScheduler"):
+            return APSchedulerService(mock_engine, mock_task_runner)
+
+    def test_init_creates_stale_task_reaper(self, service: APSchedulerService) -> None:
+        """Test __init__ creates StaleTaskReaper instance."""
+        from bookcard.services.tasks.stale_task_reaper import StaleTaskReaper
+
+        assert isinstance(service._stale_task_reaper, StaleTaskReaper)
+
+    def test_start_registers_reaper_job(self, service: APSchedulerService) -> None:
+        """Test start() registers the reaper as an interval job."""
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.running = False
+        with patch.object(service, "refresh_jobs"):
+            service.start()
+
+        # The reaper job should be registered via add_job
+        add_job_calls = mock_scheduler.add_job.call_args_list
+        reaper_calls = [
+            c
+            for c in add_job_calls
+            if c.kwargs.get("id") == "_internal_stale_task_reaper"
+        ]
+        assert len(reaper_calls) == 1
+        call_kwargs = reaper_calls[0].kwargs
+        assert call_kwargs["replace_existing"] is True
+        # Bound methods create new objects each access; compare underlying function + instance
+        func = call_kwargs["func"]
+        assert func.__func__ is type(service._stale_task_reaper).reap
+        assert func.__self__ is service._stale_task_reaper
+
+    def test_reaper_registered_before_refresh_jobs(
+        self, service: APSchedulerService
+    ) -> None:
+        """Test the reaper is registered before refresh_jobs is called."""
+        call_order: list[str] = []
+
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.running = False
+
+        def track_add_job(*args: object, **kwargs: object) -> None:
+            if kwargs.get("id") == "_internal_stale_task_reaper":
+                call_order.append("reaper_registered")
+
+        mock_scheduler.add_job.side_effect = track_add_job
+
+        def track_refresh() -> None:
+            call_order.append("refresh_jobs")
+
+        with patch.object(service, "refresh_jobs", side_effect=track_refresh):
+            service.start()
+
+        assert call_order == ["reaper_registered", "refresh_jobs"]
+
+
+class TestRemoveUserJobs:
+    """Tests for _remove_user_jobs method."""
+
+    @pytest.fixture
+    def mock_engine(self) -> MagicMock:
+        """Mock SQLAlchemy engine."""
+        return MagicMock(spec=Engine)
+
+    @pytest.fixture
+    def mock_task_runner(self) -> MagicMock:
+        """Mock task runner."""
+        return MagicMock(spec=TaskRunner)
+
+    @pytest.fixture
+    def service(
+        self, mock_engine: MagicMock, mock_task_runner: MagicMock
+    ) -> APSchedulerService:
+        """Create service instance with mocks."""
+        with patch("bookcard.services.scheduler.service.BackgroundScheduler"):
+            return APSchedulerService(mock_engine, mock_task_runner)
+
+    def test_removes_user_jobs(self, service: APSchedulerService) -> None:
+        """Test user jobs are removed."""
+        user_job = MagicMock()
+        user_job.id = "my_custom_job"
+
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.get_jobs.return_value = [user_job]
+
+        service._remove_user_jobs()
+
+        user_job.remove.assert_called_once()
+
+    def test_preserves_internal_jobs(self, service: APSchedulerService) -> None:
+        """Test internal jobs (prefixed _internal_) are preserved."""
+        internal_job = MagicMock()
+        internal_job.id = "_internal_stale_task_reaper"
+
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.get_jobs.return_value = [internal_job]
+
+        service._remove_user_jobs()
+
+        internal_job.remove.assert_not_called()
+
+    def test_mixed_jobs(self, service: APSchedulerService) -> None:
+        """Test correct handling of mixed user and internal jobs."""
+        user_job_1 = MagicMock()
+        user_job_1.id = "pvr_download_monitor"
+        user_job_2 = MagicMock()
+        user_job_2.id = "epub_fix_daily_scan"
+        internal_job = MagicMock()
+        internal_job.id = "_internal_stale_task_reaper"
+
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.get_jobs.return_value = [user_job_1, internal_job, user_job_2]
+
+        service._remove_user_jobs()
+
+        user_job_1.remove.assert_called_once()
+        user_job_2.remove.assert_called_once()
+        internal_job.remove.assert_not_called()
+
+    def test_empty_job_list(self, service: APSchedulerService) -> None:
+        """Test no-op when there are no jobs."""
+        mock_scheduler = cast("MagicMock", service._scheduler)
+        mock_scheduler.get_jobs.return_value = []
+
+        service._remove_user_jobs()
+
+
+class TestHasActiveTaskOfType:
+    """Tests for _has_active_task_of_type on the scheduler."""
+
+    @pytest.fixture
+    def mock_engine(self) -> MagicMock:
+        """Mock SQLAlchemy engine."""
+        return MagicMock(spec=Engine)
+
+    @pytest.fixture
+    def mock_task_runner(self) -> MagicMock:
+        """Mock task runner."""
+        return MagicMock(spec=TaskRunner)
+
+    @pytest.fixture
+    def service(
+        self, mock_engine: MagicMock, mock_task_runner: MagicMock
+    ) -> APSchedulerService:
+        """Create service instance with mocks."""
+        with patch("bookcard.services.scheduler.service.BackgroundScheduler"):
+            return APSchedulerService(mock_engine, mock_task_runner)
+
+    def test_returns_true_when_active_task_exists(
+        self, service: APSchedulerService
+    ) -> None:
+        """Test returns True when TaskService finds an active task."""
+        mock_task_service = MagicMock()
+        mock_task_service.has_active_task_of_type.return_value = True
+
+        mock_session = MagicMock()
+        with (
+            patch(
+                "bookcard.services.scheduler.service.Session",
+                return_value=mock_session,
+            ),
+            patch(
+                "bookcard.services.scheduler.service.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            result = service._has_active_task_of_type(TaskType.LIBRARY_SCAN)
+
+        assert result is True
+
+    def test_returns_false_when_no_active_task(
+        self, service: APSchedulerService
+    ) -> None:
+        """Test returns False when no active task found."""
+        mock_task_service = MagicMock()
+        mock_task_service.has_active_task_of_type.return_value = False
+
+        mock_session = MagicMock()
+        with (
+            patch(
+                "bookcard.services.scheduler.service.Session",
+                return_value=mock_session,
+            ),
+            patch(
+                "bookcard.services.scheduler.service.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            result = service._has_active_task_of_type(TaskType.LIBRARY_SCAN)
+
+        assert result is False
+
+    def test_returns_false_on_db_error(self, service: APSchedulerService) -> None:
+        """Test returns False (safe default) when database query fails."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        with patch(
+            "bookcard.services.scheduler.service.Session",
+            side_effect=SQLAlchemyError("Connection lost"),
+        ):
+            result = service._has_active_task_of_type(TaskType.LIBRARY_SCAN)
+
+        assert result is False

--- a/tests/services/tasks/test_stale_task_reaper.py
+++ b/tests/services/tasks/test_stale_task_reaper.py
@@ -1,0 +1,365 @@
+# Copyright (C) 2025 knguyen and others
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for StaleTaskReaper service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from bookcard.models.config import ScheduledTasksConfig
+from bookcard.models.tasks import Task, TaskStatus, TaskType
+from bookcard.services.tasks.base import TaskRunner
+from bookcard.services.tasks.stale_task_reaper import StaleTaskReaper
+
+
+@pytest.fixture
+def mock_engine() -> MagicMock:
+    """Return mock SQLAlchemy engine."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_task_runner() -> MagicMock:
+    """Return mock task runner."""
+    return MagicMock(spec=TaskRunner)
+
+
+@pytest.fixture
+def reaper(mock_engine: MagicMock, mock_task_runner: MagicMock) -> StaleTaskReaper:
+    """Create StaleTaskReaper instance with mocks."""
+    return StaleTaskReaper(mock_engine, mock_task_runner)
+
+
+class TestStaleTaskReaperInit:
+    """Test StaleTaskReaper initialization."""
+
+    def test_init_stores_dependencies(
+        self, mock_engine: MagicMock, mock_task_runner: MagicMock
+    ) -> None:
+        """Test __init__ stores engine and task runner."""
+        reaper = StaleTaskReaper(mock_engine, mock_task_runner)
+        assert reaper._engine is mock_engine
+        assert reaper._task_runner is mock_task_runner
+
+
+class TestReap:
+    """Test reap method."""
+
+    def test_reap_returns_zero_when_no_config(self, reaper: StaleTaskReaper) -> None:
+        """Test reap returns 0 when ScheduledTasksConfig is missing."""
+        with patch.object(reaper, "_get_max_runtime_seconds", return_value=None):
+            assert reaper.reap() == 0
+
+    def test_reap_returns_zero_when_no_stale_tasks(
+        self, reaper: StaleTaskReaper
+    ) -> None:
+        """Test reap returns 0 when no stale tasks found."""
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = []
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+            assert reaper.reap() == 0
+
+    def test_reap_fails_and_cancels_stale_tasks(
+        self, reaper: StaleTaskReaper, mock_task_runner: MagicMock
+    ) -> None:
+        """Test reap marks stale tasks as FAILED and sends cancel signal."""
+        stale_task = Task(
+            id=42,
+            task_type=TaskType.LIBRARY_SCAN,
+            status=TaskStatus.RUNNING,
+            user_id=1,
+            started_at=datetime.now(UTC) - timedelta(hours=12),
+        )
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = [stale_task]
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = reaper.reap()
+
+            assert result == 1
+            mock_task_runner.cancel.assert_called_once_with(42)
+            mock_task_service.fail_task.assert_called_once()
+            call_args = mock_task_service.fail_task.call_args
+            assert call_args[0][0] == 42
+            assert "reaped by watchdog" in call_args[0][1]
+
+    def test_reap_multiple_stale_tasks(
+        self, reaper: StaleTaskReaper, mock_task_runner: MagicMock
+    ) -> None:
+        """Test reap handles multiple stale tasks."""
+        stale_tasks = [
+            Task(
+                id=i,
+                task_type=TaskType.LIBRARY_SCAN,
+                status=TaskStatus.RUNNING,
+                user_id=1,
+                started_at=datetime.now(UTC) - timedelta(hours=12),
+            )
+            for i in range(1, 4)
+        ]
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = stale_tasks
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = reaper.reap()
+
+            assert result == 3
+            assert mock_task_runner.cancel.call_count == 3
+            assert mock_task_service.fail_task.call_count == 3
+
+    def test_reap_skips_task_with_none_id(
+        self, reaper: StaleTaskReaper, mock_task_runner: MagicMock
+    ) -> None:
+        """Test reap skips tasks with id=None."""
+        task_no_id = Task(
+            id=None,
+            task_type=TaskType.LIBRARY_SCAN,
+            status=TaskStatus.RUNNING,
+            user_id=1,
+        )
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = [task_no_id]
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = reaper.reap()
+
+            assert result == 0
+            mock_task_runner.cancel.assert_not_called()
+            mock_task_service.fail_task.assert_not_called()
+
+    def test_reap_continues_when_cancel_raises(
+        self, reaper: StaleTaskReaper, mock_task_runner: MagicMock
+    ) -> None:
+        """Test reap continues processing when task_runner.cancel raises."""
+        stale_task = Task(
+            id=42,
+            task_type=TaskType.LIBRARY_SCAN,
+            status=TaskStatus.RUNNING,
+            user_id=1,
+            started_at=datetime.now(UTC) - timedelta(hours=12),
+        )
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = [stale_task]
+        mock_task_runner.cancel.side_effect = SQLAlchemyError("DB error")
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = reaper.reap()
+
+            assert result == 1
+            mock_task_service.fail_task.assert_called_once()
+
+    def test_reap_returns_zero_on_db_error(self, reaper: StaleTaskReaper) -> None:
+        """Test reap returns 0 when database scan fails."""
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=36000),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session",
+                side_effect=SQLAlchemyError("Connection lost"),
+            ),
+        ):
+            assert reaper.reap() == 0
+
+    def test_reap_error_message_contains_hours(
+        self, reaper: StaleTaskReaper, mock_task_runner: MagicMock
+    ) -> None:
+        """Test the error message includes human-readable hours."""
+        stale_task = Task(
+            id=1,
+            task_type=TaskType.EPUB_FIX_DAILY_SCAN,
+            status=TaskStatus.RUNNING,
+            user_id=1,
+            started_at=datetime.now(UTC) - timedelta(hours=15),
+        )
+        mock_task_service = MagicMock()
+        mock_task_service.find_stale_running_tasks.return_value = [stale_task]
+
+        with (
+            patch.object(reaper, "_get_max_runtime_seconds", return_value=7200),
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.Session"
+            ) as mock_session_cls,
+            patch(
+                "bookcard.services.tasks.stale_task_reaper.TaskService",
+                return_value=mock_task_service,
+            ),
+        ):
+            mock_session_cls.return_value.__enter__ = MagicMock(
+                return_value=MagicMock()
+            )
+            mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            reaper.reap()
+
+            error_msg = mock_task_service.fail_task.call_args[0][1]
+            assert "2h" in error_msg
+            assert "reaped by watchdog" in error_msg
+
+
+class TestGetMaxRuntimeSeconds:
+    """Test _get_max_runtime_seconds method."""
+
+    def test_returns_seconds_from_config(self, reaper: StaleTaskReaper) -> None:
+        """Test returns duration_hours * 3600 when config exists."""
+        config = ScheduledTasksConfig(duration_hours=10)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = config
+
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            return_value=mock_session,
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            result = reaper._get_max_runtime_seconds()
+            assert result == 36000
+
+    def test_returns_none_when_no_config(self, reaper: StaleTaskReaper) -> None:
+        """Test returns None when ScheduledTasksConfig row doesn't exist."""
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = None
+
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            return_value=mock_session,
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            assert reaper._get_max_runtime_seconds() is None
+
+    def test_returns_none_on_db_error(self, reaper: StaleTaskReaper) -> None:
+        """Test returns None when database read fails."""
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            side_effect=SQLAlchemyError("Connection error"),
+        ):
+            assert reaper._get_max_runtime_seconds() is None
+
+    def test_returns_none_for_invalid_duration(self, reaper: StaleTaskReaper) -> None:
+        """Test returns None when duration_hours is not a valid int."""
+        config = MagicMock()
+        config.duration_hours = "invalid"
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = config
+
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            return_value=mock_session,
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            assert reaper._get_max_runtime_seconds() is None
+
+    def test_returns_none_for_zero_duration(self, reaper: StaleTaskReaper) -> None:
+        """Test returns None when duration_hours is zero."""
+        config = ScheduledTasksConfig(duration_hours=0)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = config
+
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            return_value=mock_session,
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            assert reaper._get_max_runtime_seconds() is None
+
+    def test_returns_none_for_negative_duration(self, reaper: StaleTaskReaper) -> None:
+        """Test returns None when duration_hours is negative."""
+        config = ScheduledTasksConfig(duration_hours=-5)
+        mock_session = MagicMock()
+        mock_session.exec.return_value.first.return_value = config
+
+        with patch(
+            "bookcard.services.tasks.stale_task_reaper.Session",
+            return_value=mock_session,
+        ):
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=False)
+            assert reaper._get_max_runtime_seconds() is None

--- a/tests/services/tasks/test_task_executor.py
+++ b/tests/services/tasks/test_task_executor.py
@@ -269,3 +269,101 @@ class TestFormatError:
         error = ValueError("Something went wrong")
         result = executor._format_error(error)
         assert "ValueError: Something went wrong" in result
+
+
+class TestTerminalStateGuard:
+    """Test that execute_task respects terminal states set externally.
+
+    When a task is marked as FAILED by the timeout timer or stale task reaper
+    while run() is still executing, execute_task must not overwrite the
+    terminal state with COMPLETED.
+    """
+
+    def test_skips_completion_when_already_failed(
+        self,
+        executor: TaskExecutor,
+        mock_task_instance: MagicMock,
+        worker_context: dict[str, MagicMock],
+    ) -> None:
+        """Test execute_task skips completion when task is already FAILED."""
+        task_id = 1
+        mock_task = Task(
+            id=task_id,
+            task_type="book_upload",
+            status=TaskStatus.FAILED,
+            user_id=1,
+            error_message="Task exceeded maximum runtime of 10h",
+        )
+        executor._task_service.get_task.return_value = mock_task  # type: ignore[attr-defined]
+        mock_task_instance.run.return_value = None
+
+        executor.execute_task(task_id, mock_task_instance, worker_context)
+
+        mock_task_instance.run.assert_called_once()
+        executor._task_service.complete_task.assert_not_called()  # type: ignore[attr-defined]
+        executor._task_service.record_task_completion.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_skips_completion_when_already_completed(
+        self,
+        executor: TaskExecutor,
+        mock_task_instance: MagicMock,
+        worker_context: dict[str, MagicMock],
+    ) -> None:
+        """Test execute_task skips completion when task is already COMPLETED."""
+        task_id = 1
+        mock_task = Task(
+            id=task_id,
+            task_type="book_upload",
+            status=TaskStatus.COMPLETED,
+            user_id=1,
+        )
+        executor._task_service.get_task.return_value = mock_task  # type: ignore[attr-defined]
+        mock_task_instance.run.return_value = None
+
+        executor.execute_task(task_id, mock_task_instance, worker_context)
+
+        executor._task_service.complete_task.assert_not_called()  # type: ignore[attr-defined]
+        executor._task_service.record_task_completion.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_does_not_overwrite_failed_on_exception(
+        self,
+        executor: TaskExecutor,
+        mock_task_instance: MagicMock,
+        worker_context: dict[str, MagicMock],
+    ) -> None:
+        """Test exception path does not overwrite FAILED set by timeout."""
+        task_id = 1
+        mock_task = Task(
+            id=task_id,
+            task_type="book_upload",
+            status=TaskStatus.FAILED,
+            user_id=1,
+            error_message="Task exceeded maximum runtime of 10h",
+        )
+        executor._task_service.get_task.return_value = mock_task  # type: ignore[attr-defined]
+        mock_task_instance.run.side_effect = RuntimeError("timeout side-effect")
+
+        executor.execute_task(task_id, mock_task_instance, worker_context)
+
+        executor._task_service.fail_task.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_does_not_overwrite_cancelled_on_exception(
+        self,
+        executor: TaskExecutor,
+        mock_task_instance: MagicMock,
+        worker_context: dict[str, MagicMock],
+    ) -> None:
+        """Test exception path does not overwrite CANCELLED status."""
+        task_id = 1
+        mock_task = Task(
+            id=task_id,
+            task_type="book_upload",
+            status=TaskStatus.CANCELLED,
+            user_id=1,
+        )
+        executor._task_service.get_task.return_value = mock_task  # type: ignore[attr-defined]
+        mock_task_instance.run.side_effect = RuntimeError("cancel side-effect")
+
+        executor.execute_task(task_id, mock_task_instance, worker_context)
+
+        executor._task_service.fail_task.assert_not_called()  # type: ignore[attr-defined]

--- a/tests/services/tasks/thread_runner/test_runner.py
+++ b/tests/services/tasks/thread_runner/test_runner.py
@@ -491,3 +491,143 @@ class TestShutdown:
 
             mock_thread.join.assert_called_once()
             assert runner._shutdown_event.is_set()
+
+
+class TestGetScheduledTaskTimeoutSeconds:
+    """Test _get_scheduled_task_timeout_seconds static method."""
+
+    @pytest.mark.parametrize(
+        ("metadata", "expected"),
+        [
+            (None, None),
+            ({}, None),
+            ({"scheduled": False}, None),
+            ({"scheduled": True}, None),
+            ({"scheduled": True, "max_runtime_seconds": 0}, None),
+            ({"scheduled": True, "max_runtime_seconds": -1}, None),
+            ({"scheduled": True, "max_runtime_seconds": "bad"}, None),
+            ({"scheduled": True, "max_runtime_seconds": 3600}, 3600.0),
+            ({"scheduled": True, "max_runtime_seconds": 7200.5}, 7200.5),
+            ({"max_runtime_seconds": 3600}, None),
+        ],
+    )
+    def test_extracts_timeout(
+        self, metadata: dict | None, expected: float | None
+    ) -> None:
+        """Test timeout extraction for various metadata inputs."""
+        assert (
+            ThreadTaskRunner._get_scheduled_task_timeout_seconds(metadata) == expected
+        )
+
+
+class TestCancelForTimeout:
+    """Test _cancel_for_timeout method."""
+
+    def test_marks_task_as_failed_not_cancelled(
+        self, mock_engine: MagicMock, mock_task_factory: MagicMock
+    ) -> None:
+        """Test timeout marks task as FAILED with descriptive error message."""
+        with patch(
+            "bookcard.services.tasks.thread_runner.runner._get_session"
+        ) as mock_get_session:
+            mock_session = MagicMock()
+            mock_get_session.return_value.__enter__.return_value = mock_session
+            mock_task_service = MagicMock(spec=TaskService)
+            with patch(
+                "bookcard.services.tasks.thread_runner.runner.TaskService",
+                return_value=mock_task_service,
+            ):
+                runner = ThreadTaskRunner(mock_engine, mock_task_factory)
+
+                mock_task_instance = MagicMock(spec=BaseTask)
+                runner._running_tasks[1] = mock_task_instance
+
+                runner._cancel_for_timeout(task_id=1, timeout_seconds=7200.0)
+
+                mock_task_instance.mark_cancelled.assert_called_once()
+                mock_task_service.fail_task.assert_called_once()
+                call_args = mock_task_service.fail_task.call_args
+                assert call_args[0][0] == 1
+                assert "2h" in call_args[0][1]
+                assert "exceeded maximum runtime" in call_args[0][1]
+
+                runner.shutdown()
+
+    def test_cooperative_signal_sent_even_if_task_not_running(
+        self, mock_engine: MagicMock, mock_task_factory: MagicMock
+    ) -> None:
+        """Test timeout still calls fail_task when task not in _running_tasks."""
+        with patch(
+            "bookcard.services.tasks.thread_runner.runner._get_session"
+        ) as mock_get_session:
+            mock_session = MagicMock()
+            mock_get_session.return_value.__enter__.return_value = mock_session
+            mock_task_service = MagicMock(spec=TaskService)
+            with patch(
+                "bookcard.services.tasks.thread_runner.runner.TaskService",
+                return_value=mock_task_service,
+            ):
+                runner = ThreadTaskRunner(mock_engine, mock_task_factory)
+
+                runner._cancel_for_timeout(task_id=999, timeout_seconds=3600.0)
+
+                mock_task_service.fail_task.assert_called_once()
+                assert "1h" in mock_task_service.fail_task.call_args[0][1]
+
+                runner.shutdown()
+
+    def test_handles_db_error_gracefully(
+        self, mock_engine: MagicMock, mock_task_factory: MagicMock
+    ) -> None:
+        """Test timeout handles SQLAlchemyError without raising."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        with patch(
+            "bookcard.services.tasks.thread_runner.runner._get_session"
+        ) as mock_get_session:
+            mock_session = MagicMock()
+            mock_get_session.return_value.__enter__.return_value = mock_session
+            mock_task_service = MagicMock(spec=TaskService)
+            mock_task_service.fail_task.side_effect = SQLAlchemyError("DB error")
+            with patch(
+                "bookcard.services.tasks.thread_runner.runner.TaskService",
+                return_value=mock_task_service,
+            ):
+                runner = ThreadTaskRunner(mock_engine, mock_task_factory)
+
+                runner._cancel_for_timeout(task_id=1, timeout_seconds=3600.0)
+
+                runner.shutdown()
+
+    @pytest.mark.parametrize(
+        ("timeout_seconds", "expected_hours"),
+        [
+            (3600.0, "1h"),
+            (7200.0, "2h"),
+            (36000.0, "10h"),
+            (5400.0, "1.5h"),
+        ],
+    )
+    def test_error_message_formats_hours(
+        self,
+        mock_engine: MagicMock,
+        mock_task_factory: MagicMock,
+        timeout_seconds: float,
+        expected_hours: str,
+    ) -> None:
+        """Test the error message contains correctly formatted hours."""
+        with patch(
+            "bookcard.services.tasks.thread_runner.runner._get_session"
+        ) as mock_get_session:
+            mock_session = MagicMock()
+            mock_get_session.return_value.__enter__.return_value = mock_session
+            mock_task_service = MagicMock(spec=TaskService)
+            with patch(
+                "bookcard.services.tasks.thread_runner.runner.TaskService",
+                return_value=mock_task_service,
+            ):
+                runner = ThreadTaskRunner(mock_engine, mock_task_factory)
+                runner._cancel_for_timeout(task_id=1, timeout_seconds=timeout_seconds)
+                error_msg = mock_task_service.fail_task.call_args[0][1]
+                assert expected_hours in error_msg
+                runner.shutdown()

--- a/tests/services/test_task_service.py
+++ b/tests/services/test_task_service.py
@@ -924,3 +924,76 @@ class TestRecordTaskCompletion:
         session.set_exec_result([mock_row])
         task_service.record_task_completion(1, TaskStatus.COMPLETED)
         assert task_statistics.total_count == 1
+
+
+class TestHasActiveTaskOfType:
+    """Test has_active_task_of_type method."""
+
+    def test_returns_true_when_active_task_exists(
+        self, task_service: TaskService, session: DummySession
+    ) -> None:
+        """Test returns True when a PENDING/RUNNING task of the type exists."""
+        session.set_exec_result([1])
+        result = task_service.has_active_task_of_type(TaskType.LIBRARY_SCAN)
+        assert result is True
+
+    def test_returns_false_when_no_active_task(
+        self, task_service: TaskService, session: DummySession
+    ) -> None:
+        """Test returns False when no active task of the type exists."""
+        session.set_exec_result([0])
+        result = task_service.has_active_task_of_type(TaskType.LIBRARY_SCAN)
+        assert result is False
+
+    @pytest.mark.parametrize("task_type", list(TaskType))
+    def test_works_for_all_task_types(
+        self, task_service: TaskService, session: DummySession, task_type: TaskType
+    ) -> None:
+        """Test works for every TaskType variant."""
+        session.set_exec_result([0])
+        result = task_service.has_active_task_of_type(task_type)
+        assert result is False
+
+
+class TestFindStaleRunningTasks:
+    """Test find_stale_running_tasks method."""
+
+    def test_returns_stale_tasks(
+        self, task_service: TaskService, session: DummySession
+    ) -> None:
+        """Test returns tasks that have exceeded max_age_seconds."""
+        stale_task = Task(
+            id=10,
+            task_type=TaskType.LIBRARY_SCAN,
+            status=TaskStatus.RUNNING,
+            user_id=1,
+        )
+        session.set_exec_result([stale_task])
+        result = task_service.find_stale_running_tasks(3600)
+        assert len(result) == 1
+        assert result[0].id == 10
+
+    def test_returns_empty_when_no_stale_tasks(
+        self, task_service: TaskService, session: DummySession
+    ) -> None:
+        """Test returns empty list when no stale tasks exist."""
+        session.set_exec_result([])
+        result = task_service.find_stale_running_tasks(3600)
+        assert result == []
+
+    def test_returns_multiple_stale_tasks(
+        self, task_service: TaskService, session: DummySession
+    ) -> None:
+        """Test returns all stale tasks."""
+        tasks = [
+            Task(
+                id=i,
+                task_type=TaskType.LIBRARY_SCAN,
+                status=TaskStatus.RUNNING,
+                user_id=1,
+            )
+            for i in range(1, 4)
+        ]
+        session.set_exec_result(tasks)
+        result = task_service.find_stale_running_tasks(7200)
+        assert len(result) == 3


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [ ] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**: Scheduled tasks were not honoring the configured max duration setting — hung tasks would run indefinitely, consume worker pool slots, and queue up duplicate instances causing system instability. This PR adds three defense layers: pre-enqueue deduplication, improved cooperative timeout with FAILED status, and a periodic stale task reaper watchdog.

# Problem

The `duration_hours` setting in `ScheduledTasksConfig` was not being effectively enforced:

1. **Cooperative cancellation was insufficient** — the `threading.Timer` + `mark_cancelled()` mechanism only sets a flag. If a task is blocked on I/O and never polls `check_cancelled()`, the thread runs forever. Python threads cannot be forcibly killed.
2. **No pre-enqueue deduplication** — `APSchedulerService._execute_task()` blindly enqueued a new task every cron trigger, even if the previous instance was still hung. APScheduler's `max_instances=1` only prevents concurrent scheduler callbacks, not concurrent task execution.
3. **No stale task watchdog** — there was no background process to detect RUNNING tasks that exceeded their max duration and mark them as failed in the database.

The cascading effect: hung threads consumed all 8 worker pool slots, the `ThreadPoolExecutor` queued new submissions internally, and the system ground to a halt.

# Solution

Three defense layers following industry best practices (Celery `TimeLimitExceeded` / Sidekiq timeout pattern):

**Layer 1 — Prevention:** `APSchedulerService._execute_task()` now checks `TaskService.has_active_task_of_type()` before enqueueing. If a PENDING or RUNNING task of the same type already exists, the enqueue is skipped with a warning log.

**Layer 2 — Cooperative timeout:** `ThreadTaskRunner._cancel_for_timeout()` now marks tasks as **FAILED** (not CANCELLED) with a descriptive error message ("Task exceeded maximum runtime of Nh"), distinguishing system timeouts from user-initiated cancellations. `TaskExecutor.execute_task()` now checks `task.is_complete` (any terminal state) instead of only `TaskStatus.CANCELLED`, preventing a timed-out task from being overwritten as COMPLETED.

**Layer 3 — Stale task reaper:** New `StaleTaskReaper` service runs every 5 minutes via APScheduler. It queries for RUNNING tasks that have exceeded `duration_hours`, sends a cooperative cancel signal, and marks them as FAILED with "(reaped by watchdog)" in the error message. `refresh_jobs()` now preserves internal jobs (prefixed `_internal_`) across refreshes.

### Files changed

| File | Change |
|------|--------|
| `bookcard/services/task_service.py` | Added `has_active_task_of_type()` and `find_stale_running_tasks()` query helpers |
| `bookcard/services/tasks/stale_task_reaper.py` | **New** — stale task reaper service (SRP) |
| `bookcard/services/scheduler/service.py` | Pre-enqueue guard, reaper registration, `_remove_user_jobs()` |
| `bookcard/services/tasks/thread_runner/runner.py` | `_cancel_for_timeout()` uses FAILED status with error message |
| `bookcard/services/tasks/task_executor.py` | Terminal state guard using `is_complete` |
| 5 test files | 70 new tests covering all changes |

# Action

Additional actions required:
* [ ] Update documentation
* [ ] Other (please specify below)

Made with [Cursor](https://cursor.com)